### PR TITLE
chore(cli): update version from 0.0.2 to 0.0.20 to reflect new change…

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roxygens/ui-startkit",
-  "version": "0.0.2",
+  "version": "0.0.20",
   "description": "Adicione componentes reutilizáveis ao seu projeto",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
…s in the package

<!-- greptile_comment -->

## Greptile Summary

This PR performs a version bump for the CLI package from 0.0.2 to 0.0.20. The CLI tool is part of the `@roxygens/ui-startkit` monorepo and is designed for managing UI components in Tailwind CSS projects. The package is configured to be published to GitHub Packages as indicated by the publishConfig in the package.json.

The version update is straightforward - only the version field in `packages/cli/package.json` has been modified. This change enables users to access the latest functionality through the updated package version. The CLI tool serves as a command-line interface for project initialization and component management within the broader UI startkit ecosystem.

The substantial jump from 0.0.2 to 0.0.20 (an increment of 18 patch versions) suggests this update consolidates multiple changes, features, or fixes that have been developed but not yet released. This is common in development workflows where version numbers are updated infrequently to batch multiple changes together.

## Important Files Changed

<details>
<summary>Files Modified (1)</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/cli/package.json | 5/5 | Simple version bump from 0.0.2 to 0.0.20 with no other changes |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects a simple, isolated version number change with no functional modifications
- No files require special attention

<!-- /greptile_comment -->