### PR TITLE
feat(cli): add function to retrieve npm token from .npmrc for improve…

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,13 @@ import chalk from 'chalk'
 
 const program = new Command()
 
+function getNpmToken() {
+  const npmrcPath = path.resolve(process.cwd(), '.npmrc')
+  const npmrc = fs.readFileSync(npmrcPath, 'utf-8')
+  const match = npmrc.match(new RegExp(`^//npm\\.pkg\\.github\\.com/:_authToken=(.+)$`, 'm'))
+  return match ? match[1] : null
+}
+
 // =================================================================
 // COMANDO INIT (ATUALIZADO COM O TEMA DO FIGMA PARA TAILWIND v4)
 // =================================================================
@@ -269,8 +276,10 @@ program
       const REGISTRY_API_URL =
         'https://api.github.com/repos/roxygens/ui-startkit/contents/registry.json'
 
+      const token = getNpmToken()
+
       const response = await fetch(REGISTRY_API_URL, {
-        headers: { Authorization: `token ${process.env.GITHUB_TOKEN}` },
+        headers: { Authorization: `token ${token}` },
       })
 
       const fileData: any = await response.json()
@@ -303,7 +312,7 @@ program
 
       for (const file of componentData.files) {
         const fileResponse = await fetch(file.contentUrl, {
-          headers: { Authorization: `token ${process.env.GITHUB_TOKEN}` },
+          headers: { Authorization: `token ${token}` },
         })
 
         if (!fileResponse.ok) {


### PR DESCRIPTION
…d authentication handling

refactor(cli): replace hardcoded GITHUB_TOKEN with dynamic token retrieval for fetch requests

<!-- greptile_comment -->

## Greptile Summary

This PR refactors the CLI's authentication mechanism by replacing hardcoded environment variable usage with dynamic token retrieval from `.npmrc` files. The change adds a `getNpmToken()` function that reads authentication tokens from the standard npm configuration file and applies this token to GitHub Packages API requests.

The modification aligns the CLI tool with npm ecosystem conventions, where authentication tokens are typically stored in `.npmrc` files rather than environment variables. This change affects the component registry fetching functionality, specifically the API calls to `REGISTRY_API_URL` and individual component file downloads. The refactor makes the tool more user-friendly by following standard npm authentication practices, eliminating the need for developers to manually set `GITHUB_TOKEN` environment variables.

This change fits within the broader context of the ui-startkit CLI tool, which is designed to manage and install UI components from GitHub Packages. The authentication improvement supports the tool's core functionality of fetching component metadata and files from the remote registry.

## Important Files Changed

<details>
<summary>File Changes</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/cli/src/index.ts | 1/5 | Added `getNpmToken()` function and replaced hardcoded `GITHUB_TOKEN` with dynamic token retrieval, but implementation lacks critical error handling |

</details>

## Confidence score: 1/5

- This PR introduces significant reliability risks due to missing error handling and could cause the CLI to crash in common scenarios
- Score reflects critical implementation flaws including lack of file existence checks, no fallback mechanisms, and overly restrictive regex patterns
- Pay close attention to packages/cli/src/index.ts as it needs comprehensive error handling before merging

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant CLI as "CLI Application"
    participant FileSystem as "File System"
    participant GitHub as "GitHub API"
    participant NPM as "NPM Registry"

    alt init command
        User->>CLI: "npx @roxygens/ui-startkit init"
        CLI->>User: "Prompt for configuration options"
        User->>CLI: "Provide tailwind CSS file, component alias, utils alias"
        CLI->>FileSystem: "Create components.json with configuration"
        CLI->>FileSystem: "Read existing CSS file"
        CLI->>FileSystem: "Write theme configuration to CSS file"
        CLI->>NPM: "Install dependencies (tailwindcss-animate, etc.)"
        NPM-->>CLI: "Dependencies installed"
        CLI->>User: "Project initialized successfully"
    else add component command
        User->>CLI: "npx @roxygens/ui-startkit add <component>"
        CLI->>FileSystem: "Read .npmrc file"
        FileSystem-->>CLI: "Return npm token"
        CLI->>GitHub: "Fetch registry.json with authentication token"
        GitHub-->>CLI: "Return registry content"
        CLI->>CLI: "Parse registry and find component data"
        alt component exists
            CLI->>FileSystem: "Read components.json configuration"
            FileSystem-->>CLI: "Return configuration"
            loop for each component file
                CLI->>GitHub: "Fetch component file content with token"
                GitHub-->>CLI: "Return file content"
                CLI->>FileSystem: "Write component file to project"
            end
            alt has dependencies
                CLI->>NPM: "Install component dependencies"
                NPM-->>CLI: "Dependencies installed"
            end
            CLI->>User: "Component installed successfully"
        else component not found
            CLI->>User: "Error: Component not found in registry"
        end
    end
```

<!-- /greptile_comment -->