### PR TITLE
fix(badge): remove 'lg' size option and update 'md' size styles for c…

### DIFF
--- a/packages/ui/src/components/ui/badge/badge.stories.tsx
+++ b/packages/ui/src/components/ui/badge/badge.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof Badge> = {
   tags: ['autodocs'],
   argTypes: {
     size: {
-      options: ['md', 'lg'],
+      options: ['md'],
       control: { type: 'select' },
     },
     variant: {

--- a/packages/ui/src/components/ui/badge/badge.test.tsx
+++ b/packages/ui/src/components/ui/badge/badge.test.tsx
@@ -10,7 +10,7 @@ describe('Badge', () => {
 
   it('should apply default variants', () => {
     const { getByText } = render(<Badge>Default Badge</Badge>)
-    expect(getByText('Default Badge').className).toContain('text-[.6rem] px-[.66rem] py-[.22rem]')
+    expect(getByText('Default Badge').className).toContain('text-[.75rem] px-[.75rem] py-[.25rem]')
     expect(getByText('Default Badge').className).toContain(
       'bg-[#3BE2C21A] border-[#3BE2C259] text-[#3BE2C2]',
     )
@@ -18,12 +18,7 @@ describe('Badge', () => {
 
   it('should apply size md', () => {
     const { getByText } = render(<Badge size="md">Medium Badge</Badge>)
-    expect(getByText('Medium Badge').className).toContain('text-[.6rem] px-[.66rem] py-[.22rem]')
-  })
-
-  it('should apply size lg', () => {
-    const { getByText } = render(<Badge size="lg">Large Badge</Badge>)
-    expect(getByText('Large Badge').className).toContain('px-[1rem] py-[.25rem] text-xs')
+    expect(getByText('Medium Badge').className).toContain('text-[.75rem] px-[.75rem] py-[.25rem]')
   })
 
   it('should apply variant success', () => {

--- a/packages/ui/src/components/ui/badge/badge.tsx
+++ b/packages/ui/src/components/ui/badge/badge.tsx
@@ -6,8 +6,7 @@ const badgeVariants = cva(
   {
     variants: {
       size: {
-        md: 'text-[.6rem] px-[.66rem] py-[.22rem]',
-        lg: 'px-[1rem] py-[.25rem] text-xs',
+        md: 'text-[.75rem] px-[.75rem] py-[.25rem]',
       },
       variant: {
         success: 'bg-[#54DC621A] border-[#54DC6259] text-[#54DC62]',


### PR DESCRIPTION
…onsistency

test(badge): update tests to reflect changes in badge size styles and remove 'lg' size test

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-05 01:31:59 UTC

This PR implements a design system consistency update for the Badge component by removing the 'lg' size variant and modifying the 'md' size styling. The changes simplify the Badge API from supporting two size options ('md' and 'lg') to just one ('md'), while updating the 'md' size with larger, more consistent dimensions.

The core change occurs in the Badge component's `badgeVariants` configuration where the 'lg' size is completely removed from the size variants object. The remaining 'md' size receives updated styling with increased font size (from .6rem to .75rem), horizontal padding (from .66rem to .75rem), and vertical padding (from .22rem to .25rem). These new values use consistent .75rem measurements across text size and horizontal padding, creating better visual harmony.

To maintain consistency across the codebase, the changes cascade through the component's ecosystem. The Storybook configuration is updated to remove 'lg' from the available size options, preventing users from selecting a non-existent variant in the component explorer. The test suite is comprehensively updated to reflect the new CSS class expectations and removes the obsolete 'lg' size test case.

This change fits into the broader ui-startkit design system by promoting consistency and reducing complexity. The startkit serves as a foundation for building user interfaces with reusable components, and having fewer, well-defined size options makes the system more predictable and easier to maintain. The uniform rem values also align with modern CSS best practices for scalable design systems.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/ui/src/components/ui/badge/badge.tsx | 4/5 | Removed 'lg' size variant and updated 'md' size with larger, more consistent padding and text dimensions |
| packages/ui/src/components/ui/badge/badge.stories.tsx | 5/5 | Updated Storybook controls to remove 'lg' size option, keeping only 'md' available |
| packages/ui/src/components/ui/badge/badge.test.tsx | 5/5 | Updated test expectations for new 'md' size CSS classes and removed obsolete 'lg' size test |

</details>

## Confidence score: 4/5

- This PR is relatively safe to merge but represents a breaking change that could impact existing consumers using the 'lg' size
- Score reflects well-maintained test coverage and consistent implementation across all component files, but lowered due to the breaking nature of removing functionality
- Pay close attention to packages/ui/src/components/ui/badge/badge.tsx to ensure the breaking change is acceptable for your use case

<!-- /greptile_comment -->