### PR TITLE
fix(badge): add rounded corners to default and medium badge styles fo…

### DIFF
--- a/packages/ui/src/components/ui/badge/badge.test.tsx
+++ b/packages/ui/src/components/ui/badge/badge.test.tsx
@@ -10,7 +10,9 @@ describe('Badge', () => {
 
   it('should apply default variants', () => {
     const { getByText } = render(<Badge>Default Badge</Badge>)
-    expect(getByText('Default Badge').className).toContain('text-[.75rem] px-[.75rem] py-[.25rem]')
+    expect(getByText('Default Badge').className).toContain(
+      'text-[.75rem] px-[.75rem] py-[.25rem] rounded-[.815rem]',
+    )
     expect(getByText('Default Badge').className).toContain(
       'bg-[#3BE2C21A] border-[#3BE2C259] text-[#3BE2C2]',
     )
@@ -18,7 +20,9 @@ describe('Badge', () => {
 
   it('should apply size md', () => {
     const { getByText } = render(<Badge size="md">Medium Badge</Badge>)
-    expect(getByText('Medium Badge').className).toContain('text-[.75rem] px-[.75rem] py-[.25rem]')
+    expect(getByText('Medium Badge').className).toContain(
+      'text-[.75rem] px-[.75rem] py-[.25rem] rounded-[.815rem]',
+    )
   })
 
   it('should apply variant success', () => {

--- a/packages/ui/src/components/ui/badge/badge.tsx
+++ b/packages/ui/src/components/ui/badge/badge.tsx
@@ -2,11 +2,11 @@ import { cn } from '@/lib/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 const badgeVariants = cva(
-  'inline-flex items-center justify-center gap-2 rounded-[1rem] border font-semibold uppercase tracking-wider w-fit',
+  'inline-flex items-center justify-center gap-2 border font-semibold uppercase tracking-wider w-fit',
   {
     variants: {
       size: {
-        md: 'text-[.75rem] px-[.75rem] py-[.25rem]',
+        md: 'text-[.75rem] px-[.75rem] py-[.25rem] rounded-[.815rem]',
       },
       variant: {
         success: 'bg-[#54DC621A] border-[#54DC6259] text-[#54DC62]',


### PR DESCRIPTION
…r better aesthetics and consistency

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-05 01:38:33 UTC

This PR modifies the badge component styling to implement a more selective approach to rounded corners. The changes remove the default `rounded-[1rem]` styling from the base badge class and instead apply `rounded-[.815rem]` specifically to the medium size variant. This creates a design system where only medium badges have rounded corners, while other size variants (if they exist) would have square corners.

The badge component is part of the UI component library in the `packages/ui` directory, which provides reusable React components built with Tailwind CSS. The badge component uses a `cva` (class-variance-authority) pattern to manage different styling variants based on props like size and visual variant. The change moves the border radius from being a universal badge property to a size-specific styling concern.

The accompanying test file has been updated to reflect these changes, with test assertions now expecting the `rounded-[.815rem]` class to be present on both default badges (which use the medium size) and explicitly medium-sized badges. This ensures the tests remain accurate to the component's actual styling behavior.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/ui/src/components/ui/badge/badge.tsx | 3/5 | Removed default rounded corners and applied specific rounded styling only to medium size variant |
| packages/ui/src/components/ui/badge/badge.test.tsx | 5/5 | Updated test assertions to match new rounded corner implementation for medium badges |

</details>

## Confidence score: 3/5

- This PR requires careful review due to potential design inconsistencies with badge sizing variants
- Score lowered because removing default rounded corners could cause square corners on non-medium badges, breaking visual consistency
- Pay close attention to packages/ui/src/components/ui/badge/badge.tsx for the sizing variant logic

<!-- /greptile_comment -->