### PR TITLE
feat(input-otp): add InputOtp component with customizable length and …

### DIFF
--- a/packages/ui/src/components/ui/input-otp/index.tsx
+++ b/packages/ui/src/components/ui/input-otp/index.tsx
@@ -1,0 +1,1 @@
+export { InputOtp } from './input-otp'

--- a/packages/ui/src/components/ui/input-otp/input-otp.stories.tsx
+++ b/packages/ui/src/components/ui/input-otp/input-otp.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { InputOtp } from '.'
+
+const meta: Meta<typeof InputOtp> = {
+  title: 'Components/InputOtp',
+  component: InputOtp,
+  parameters: {
+    docs: { page: null },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      options: ['xs', 'sm', 'md', 'lg'],
+      control: { type: 'select' },
+    },
+    'aria-invalid': {
+      control: { type: 'boolean' },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof InputOtp>
+
+export const Default: Story = {
+  args: {},
+}

--- a/packages/ui/src/components/ui/input-otp/input-otp.test.tsx
+++ b/packages/ui/src/components/ui/input-otp/input-otp.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, vi, expect } from 'vitest'
+import { InputOtp } from '.'
+
+describe('InputOtp', () => {
+  it('should render the correct number of inputs', () => {
+    render(<InputOtp length={4} type="text" />)
+    expect(screen.getAllByRole('textbox')).toHaveLength(4)
+  })
+
+  it('should call onChange with concatenated values', () => {
+    const handleChange = vi.fn()
+    render(<InputOtp length={3} onChange={handleChange} type="text" />)
+    const inputs = screen.getAllByRole('textbox')
+    fireEvent.change(inputs[0], { target: { value: 'A' } })
+    expect(handleChange).toHaveBeenCalledWith('A')
+    fireEvent.change(inputs[1], { target: { value: 'B' } })
+    expect(handleChange).toHaveBeenCalledWith('AB')
+    fireEvent.change(inputs[2], { target: { value: 'C' } })
+    expect(handleChange).toHaveBeenCalledWith('ABC')
+  })
+
+  it('should only accept numbers when type is number', () => {
+    const handleChange = vi.fn()
+    render(<InputOtp length={2} onChange={handleChange} type="number" />)
+    const inputs = screen.getAllByRole('textbox')
+    fireEvent.change(inputs[0], { target: { value: '1' } })
+    expect(handleChange).toHaveBeenCalledWith('1')
+    fireEvent.change(inputs[1], { target: { value: 'x' } })
+    expect(handleChange).not.toHaveBeenCalledWith('1x')
+  })
+
+  it('should move focus to next input when typing', () => {
+    render(<InputOtp length={2} type="text" />)
+    const inputs = screen.getAllByRole('textbox')
+    inputs[0].focus()
+    fireEvent.change(inputs[0], { target: { value: 'A' } })
+    expect(document.activeElement).toBe(inputs[1])
+  })
+
+  it('should move focus to previous input when deleting', () => {
+    render(<InputOtp length={2} type="text" />)
+    const inputs = screen.getAllByRole('textbox')
+    fireEvent.change(inputs[0], { target: { value: 'A' } })
+    fireEvent.change(inputs[1], { target: { value: 'B' } })
+    fireEvent.change(inputs[1], { target: { value: '' } })
+    expect(document.activeElement).toBe(inputs[0])
+  })
+
+  it('should handle paste with numbers when type is number', () => {
+    const handleChange = vi.fn()
+    render(<InputOtp length={4} onChange={handleChange} type="number" />)
+    const inputs = screen.getAllByRole('textbox')
+    const event = {
+      clipboardData: {
+        getData: () => '12ab34',
+      },
+      preventDefault: vi.fn(),
+    }
+    fireEvent.paste(inputs[0], event)
+    expect(handleChange).toHaveBeenCalledWith('1234')
+  })
+
+  it('should handle paste with text when type is text', () => {
+    const handleChange = vi.fn()
+    render(<InputOtp length={4} onChange={handleChange} type="text" />)
+    const inputs = screen.getAllByRole('textbox')
+    const event = {
+      clipboardData: {
+        getData: () => 'WXYZ',
+      },
+      preventDefault: vi.fn(),
+    }
+    fireEvent.paste(inputs[0], event)
+    expect(handleChange).toHaveBeenCalledWith('WXYZ')
+  })
+
+  it('should apply disabled attribute', () => {
+    render(<InputOtp length={2} disabled type="text" />)
+    const inputs = screen.getAllByRole('textbox')
+    expect(inputs[0]).toBeDisabled()
+    expect(inputs[1]).toBeDisabled()
+  })
+
+  it('should apply size variants correctly', () => {
+    render(<InputOtp length={1} size="lg" type="text" />)
+    expect(screen.getByRole('textbox').className).toContain('h-[2.5rem]')
+  })
+
+  it('should ignore paste when clipboard has no data', () => {
+    const handleChange = vi.fn()
+    render(<InputOtp length={3} onChange={handleChange} type="text" />)
+    const inputs = screen.getAllByRole('textbox')
+    const event = {
+      clipboardData: {
+        getData: () => '',
+      },
+      preventDefault: vi.fn(),
+    }
+    fireEvent.paste(inputs[0], event)
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('should fill empty values with blank when pasted data is shorter than length', () => {
+    const handleChange = vi.fn()
+    render(<InputOtp length={4} onChange={handleChange} type="text" />)
+    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[]
+    const event = {
+      clipboardData: {
+        getData: () => 'AB',
+      },
+      preventDefault: vi.fn(),
+    }
+    fireEvent.paste(inputs[0], event)
+    expect(handleChange).toHaveBeenCalledWith('AB')
+    expect(inputs[2].value).toBe('')
+    expect(inputs[3].value).toBe('')
+  })
+
+  it('should move focus to the last filled input after paste', () => {
+    render(<InputOtp length={4} type="text" />)
+    const inputs = screen.getAllByRole('textbox')
+    const event = {
+      clipboardData: {
+        getData: () => 'XYZ',
+      },
+      preventDefault: vi.fn(),
+    }
+    fireEvent.paste(inputs[0], event)
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        expect(document.activeElement).toBe(inputs[2])
+        resolve(true)
+      }, 0)
+    })
+  })
+})

--- a/packages/ui/src/components/ui/input-otp/input-otp.tsx
+++ b/packages/ui/src/components/ui/input-otp/input-otp.tsx
@@ -1,0 +1,127 @@
+import React, { useState, useEffect } from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const inputOtpVariants = cva(
+  `
+    text-white placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground  shadow-[0_1px_2px_rgba(0,0,0,0.05)]  border border-[var(--color-neutral-gray)]
+    flex w-full text-center min-w-0 rounded-0 bg-transparent text-base shadow-xs 
+    transition-[color,box-shadow] outline-none 
+    disabled:cursor-not-allowed disabled:hover:border-none  disabled:opacity-50 md:text-sm disabled:bg-[var(--disabled)] disabled:text-[var(--primary-foreground-disabled)]
+
+    hover:border-[var(--primary)] 
+
+    focus:border-[var(--primary)] 
+
+    aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive
+  `,
+  {
+    variants: {
+      size: {
+        xs: 'h-[1.5rem] w-[1.5rem]  text-xs',
+        sm: 'h-[2rem]  w-[2rem] text-sm',
+        md: 'h-[2.25rem]  w-[2.25rem] text-sm',
+        lg: 'h-[2.5rem] w-[2.5rem] text-sm',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  },
+)
+
+type OtherProps = {
+  length?: number
+  disabled?: boolean
+  type: 'text' | 'number'
+  onChange?: (value: unknown) => void
+}
+
+type InputOtpProps = Omit<React.ComponentProps<'input'>, 'size' | 'onChange' | 'type'> &
+  VariantProps<typeof inputOtpVariants> &
+  OtherProps
+
+export function InputOtp({
+  disabled,
+  type = 'text',
+  length = 6,
+  onChange,
+  className,
+  size,
+  ...rest
+}: InputOtpProps) {
+  const [values, setValues] = useState<string[]>([])
+
+  const handleChange = (index: number, val: string) => {
+    if (type === 'number') {
+      if (!/^\d?$/.test(val)) return
+    }
+
+    const newValues = [...values]
+    newValues[index] = val
+    setValues(newValues)
+    onChange?.(newValues.join(''))
+
+    if (val && index < length - 1) {
+      const nextInput = document.getElementById(`otp-input-${index + 1}`)
+      nextInput?.focus()
+    }
+
+    if (!val && index > 0) {
+      const prevInput = document.getElementById(`otp-input-${index - 1}`)
+      prevInput?.focus()
+    }
+  }
+
+  const handlePaste = (index: number, e: React.ClipboardEvent<HTMLInputElement>) => {
+    const pasteData = e.clipboardData.getData('Text')
+    if (!pasteData) return
+
+    let chars = pasteData.split('')
+    if (type === 'number') {
+      chars = chars.filter((c) => /^\d$/.test(c))
+    }
+    const newValues = [...values]
+    for (let i = index; i < length; i++) {
+      newValues[i] = chars[i - index] || ''
+    }
+    setValues(newValues)
+    onChange?.(newValues.join(''))
+
+    const lastFilled = Math.min(index + chars.length - 1, length - 1)
+    if (lastFilled >= 0) {
+      setTimeout(() => {
+        const input = document.getElementById(`otp-input-${lastFilled}`)
+        input?.focus()
+      }, 0)
+    }
+    e.preventDefault()
+  }
+
+  useEffect(() => {
+    setValues(Array(length).fill(''))
+  }, [length])
+
+  return (
+    <div className="flex gap-0">
+      {values.map((v, i) => (
+        <input
+          {...rest}
+          key={i}
+          id={`otp-input-${i}`}
+          type="text"
+          maxLength={1}
+          value={v}
+          disabled={disabled}
+          className={cn(inputOtpVariants({ size, className }), {
+            'rounded-[0.5rem]': length === 1,
+            'rounded-l-[0.5rem]': i === 0,
+            'rounded-r-[0.5rem]': i === length - 1,
+          })}
+          onChange={(e) => handleChange(i, e.target.value)}
+          onPaste={(e) => handlePaste(i, e)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/ui/src/components/ui/input-otp/input-otp.tsx
+++ b/packages/ui/src/components/ui/input-otp/input-otp.tsx
@@ -34,7 +34,7 @@ type OtherProps = {
   length?: number
   disabled?: boolean
   type: 'text' | 'number'
-  onChange?: (value: unknown) => void
+  onChange?: (value: string | number) => void
 }
 
 type InputOtpProps = Omit<React.ComponentProps<'input'>, 'size' | 'onChange' | 'type'> &

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -138,7 +138,7 @@
   }
 
   .text-sm {
-    @apply ont-normal text-[0.88rem] leading-[150%] tracking-[0.005em];
+    @apply font-normal text-[0.88rem] leading-[150%] tracking-[0.005em];
   }
 
   .text-base  {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -58,6 +58,7 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-neutral-900: #1C1C1E;
+  --color-neutral-gray: #707179;
 }
 
 :root {
@@ -130,6 +131,14 @@
 
   .text-body {
     @apply font-normal not-italic text-[11.78px] leading-[17.66px] tracking-[0] text-center ;
+  }
+
+  .text-xs {
+    @apply  font-normal text-[0.75rem] leading-[150%] tracking-[0.015em];
+  }
+
+  .text-sm {
+    @apply ont-normal text-[0.88rem] leading-[150%] tracking-[0.005em];
   }
 
   .text-base  {


### PR DESCRIPTION
…type for OTP input

feat(input-otp): create stories for InputOtp component in Storybook for documentation and testing
test(input-otp): implement unit tests for InputOtp component to ensure functionality and user interactions

feat(index.css): add new color variable for neutral gray and text size utilities for xs and sm to enhance styling options

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-09 01:41:33 UTC

This PR introduces a comprehensive InputOtp component to the UI component library, designed for One-Time Password and verification code inputs. The component provides a superior user experience compared to single input fields by offering individual character inputs with automatic focus management, input type validation (text/number), and intelligent paste handling.

The implementation follows the established patterns in the codebase, including the standard component structure with separate files for the main component, Storybook stories, unit tests, and a barrel export index file. The component integrates seamlessly with the existing design system using class-variance-authority for styling variants and follows TypeScript best practices for type safety.

Key features include:
- Customizable length for different OTP requirements
- Type validation supporting both text and numeric inputs
- Automatic focus navigation between input fields
- Smart paste functionality that filters clipboard content based on input type
- Responsive sizing options through CSS variants
- Proper accessibility support with ARIA attributes

The component uses controlled input patterns with React state management and includes comprehensive test coverage for all major functionality including rendering, user interactions, focus management, and edge cases. Supporting CSS utilities were also added to enhance the styling capabilities of the component.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/ui/src/components/ui/input-otp/input-otp.tsx | 3/5 | Main InputOtp component implementation with focus management and paste handling |
| packages/ui/src/components/ui/input-otp/input-otp.test.tsx | 3/5 | Comprehensive test suite with some potentially flaky async test patterns |
| packages/ui/src/components/ui/input-otp/input-otp.stories.tsx | 4/5 | Basic Storybook configuration following established patterns |
| packages/ui/src/components/ui/input-otp/index.tsx | 5/5 | Standard barrel export file following library conventions |
| packages/ui/src/index.css | 2/5 | CSS utilities with critical typo in text-sm class definition |

</details>

## Confidence score: 3/5

- This PR introduces useful functionality but contains critical issues that need addressing before merge
- Score reflects the presence of a CSS typo and potentially problematic DOM manipulation patterns in the main component
- Pay close attention to packages/ui/src/index.css for the typo fix and packages/ui/src/components/ui/input-otp/input-otp.tsx for the direct DOM manipulation approach

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant InputOtp
    participant DOM
    participant OnChangeCallback

    User->>InputOtp: "Types character in input field"
    InputOtp->>InputOtp: "Validates input (number/text type)"
    InputOtp->>InputOtp: "Updates values array"
    InputOtp->>OnChangeCallback: "Calls onChange with concatenated values"
    InputOtp->>DOM: "Focuses next input field"

    User->>InputOtp: "Deletes character (backspace)"
    InputOtp->>InputOtp: "Updates values array"
    InputOtp->>OnChangeCallback: "Calls onChange with updated values"
    InputOtp->>DOM: "Focuses previous input field"

    User->>InputOtp: "Pastes text/numbers"
    InputOtp->>InputOtp: "Filters paste data by type"
    InputOtp->>InputOtp: "Distributes characters across inputs"
    InputOtp->>OnChangeCallback: "Calls onChange with concatenated values"
    InputOtp->>DOM: "Focuses last filled input"
```

<!-- /greptile_comment -->