### PR TITLE
feat(registry.json): add InputOtp component with its dependencies and…

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -98,6 +98,20 @@
           "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/lib/utils.ts"
         }
       ]
+    },
+     "input-otp": {
+      "name": "InputOtp",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "components/ui/input-otp.tsx",
+          "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/input-otp/input-otp.tsx"
+        },
+        {
+          "path": "lib/utils.ts",
+          "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/lib/utils.ts"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
… file paths to the registry for better component management

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-09 01:58:27 UTC

This PR adds the InputOtp component to the `registry.json` file, making it available for installation through the project's CLI tool. The `registry.json` file serves as a centralized manifest that tracks all available UI components in the startkit, similar to how shadcn/ui manages its component registry.

The change follows the established pattern used by other components in the registry, defining the component with its name "InputOtp", an empty dependencies array (since it only uses already-available dependencies like `class-variance-authority`), and the necessary file paths for installation. The registry includes two files: the main component file (`input-otp.tsx`) and the utilities file (`utils.ts`) that contains helper functions like the `cn` utility.

This integration fits well with the overall architecture of the ui-startkit, which is designed to provide a structured approach to building and managing reusable UI components. By registering the component, developers can now use the CLI to install the InputOtp component rather than manually copying files, maintaining consistency with the project's component management system.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| registry.json | 4/5 | Added InputOtp component entry with correct structure and file paths |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it only adds a registry entry without modifying existing functionality
- Score reflects the straightforward nature of the change and adherence to established patterns in the registry
- No files require special attention as the change follows existing conventions perfectly

<!-- /greptile_comment -->