### PR TITLE
feat(ui): add RadioGroup component and its associated stories and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1789,6 +1789,38 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
@@ -9571,6 +9603,7 @@
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
         "@tailwindcss/vite": "^4.1.12",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
     "@tailwindcss/vite": "^4.1.12",

--- a/packages/ui/src/components/ui/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox/checkbox.tsx
@@ -8,7 +8,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 const checkboxVariants = cva(
   `
-    peer group shrink-0 rounded-[0.19rem] border border-white shadow-xs mt-[0.15rem]
+    peer group shrink-0 rounded-[0.19rem] border border-neutral-gray shadow-xs mt-[0.15rem]
     transition-shadow outline-none 
     data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground 
     dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary 
@@ -112,7 +112,11 @@ function Checkbox({ className, size, label, description, ...props }: Props) {
       </CheckboxPrimitive.Root>
 
       <div className="flex flex-col">
-        {label && <p className={labelVariants({ size })}>{label}</p>}
+        {label && (
+          <label htmlFor={label} className={labelVariants({ size })}>
+            {label}
+          </label>
+        )}
         {description && <p className={descriptionVariants({ size })}>{description}</p>}
       </div>
     </div>

--- a/packages/ui/src/components/ui/radio-group/index.tsx
+++ b/packages/ui/src/components/ui/radio-group/index.tsx
@@ -1,0 +1,1 @@
+export { RadioGroup } from './radio-group'

--- a/packages/ui/src/components/ui/radio-group/radio-group.stories.tsx
+++ b/packages/ui/src/components/ui/radio-group/radio-group.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { RadioGroup } from '.'
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Components/RadioGroup',
+  component: RadioGroup,
+  parameters: {
+    docs: { page: null },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      options: ['xs', 'sm', 'md', 'lg'],
+      control: { type: 'select' },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof RadioGroup>
+
+export const Default: Story = {
+  args: {
+    defaultValue: 'item_one',
+    options: [
+      {
+        label: 'Item One',
+        value: 'item_one',
+      },
+      {
+        label: 'Item Two',
+        value: 'item_two',
+      },
+      {
+        label: 'Item Three',
+        value: 'item_three',
+      },
+      {
+        label: 'Item disabled',
+        value: 'item_disabed',
+        disabled: true,
+      },
+    ],
+  },
+}

--- a/packages/ui/src/components/ui/radio-group/radio-group.test.tsx
+++ b/packages/ui/src/components/ui/radio-group/radio-group.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { RadioGroup } from '.'
+
+describe('RadioGroup', () => {
+  const options = [
+    { label: 'Option 1', value: 'opt1' },
+    { label: 'Option 2', value: 'opt2', description: 'Second option' },
+    { label: 'Option 3', value: 'opt3', disabled: true },
+  ]
+
+  it('should render all options with labels', () => {
+    render(<RadioGroup options={options} />)
+    expect(screen.getByText('Option 1')).toBeInTheDocument()
+    expect(screen.getByText('Option 2')).toBeInTheDocument()
+    expect(screen.getByText('Option 3')).toBeInTheDocument()
+  })
+
+  it('should render with description when provided', () => {
+    render(<RadioGroup options={options} />)
+    expect(screen.getByText('Second option')).toBeInTheDocument()
+  })
+
+  it('should select an option when clicked', () => {
+    render(<RadioGroup options={options} />)
+    const option1 = screen.getByLabelText('Option 1')
+    const option2 = screen.getByLabelText('Option 2')
+
+    fireEvent.click(option1)
+    expect(option1).toBeChecked()
+
+    fireEvent.click(option2)
+    expect(option2).toBeChecked()
+    expect(option1).not.toBeChecked()
+  })
+
+  it('should select defaultValue on mount', () => {
+    render(<RadioGroup options={options} defaultValue="opt2" />)
+    const option2 = screen.getByLabelText('Option 2')
+    expect(option2).toBeChecked()
+  })
+
+  it('should not allow selecting disabled option', () => {
+    render(<RadioGroup options={options} />)
+    const option3 = screen.getByLabelText('Option 3')
+    expect(option3).toBeDisabled()
+    fireEvent.click(option3)
+    expect(option3).not.toBeChecked()
+  })
+
+  it('should toggle when container is clicked if description exists', () => {
+    render(<RadioGroup options={options} />)
+    const container = screen.getByText('Second option').closest('div')
+    const option2 = screen.getByLabelText('Option 2')
+    if (container) fireEvent.click(container)
+    expect(option2).toBeChecked()
+  })
+})

--- a/packages/ui/src/components/ui/radio-group/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group/radio-group.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { type ComponentProps, useState, useEffect } from 'react'
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
+import { CircleIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const radioGroupVariants = cva(
+  `
+    shadow-xs 
+    transition-shadow outline-none 
+    focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]
+    aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive
+    disabled:cursor-not-allowed disabled:opacity-50
+  `,
+  {
+    variants: {
+      size: {
+        xs: 'h-3 w-3',
+        sm: 'h-3.5 w-3.5',
+        md: 'h-4 w-4',
+        lg: 'h-5 w-5 ',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  },
+)
+
+const labelVariants = cva('text-white font-normal', {
+  variants: {
+    size: {
+      xs: 'text-[0.75rem] leading-[1.2] tracking-[0.005rem]',
+      sm: 'text-[0.8125rem] leading-[1.3] tracking-[0.006rem]',
+      md: 'text-[0.875rem] leading-[1.5] tracking-[0.007rem]',
+      lg: 'text-[1rem] leading-[1.6] tracking-[0.01rem]',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+})
+
+const descriptionVariants = cva('text-neutral-gray', {
+  variants: {
+    size: {
+      xs: 'text-[0.625rem] leading-[1.1] tracking-[0.01em]',
+      sm: 'text-[0.6875rem] leading-[1.2] tracking-[0.012em]',
+      md: 'text-[0.75rem] leading-[1.5] tracking-[0.015em]',
+      lg: 'text-[0.875rem] leading-[1.6] tracking-[0.02em]',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+})
+
+const circleIconVariants = cva(
+  'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-primary',
+  {
+    variants: {
+      size: {
+        xs: 'size-3 stroke-[0.5rem] rounded-full',
+        sm: 'size-3.5 stroke-[0.5rem] rounded-full',
+        md: 'size-4 stroke-[0.5rem] rounded-full',
+        lg: 'size-6 stroke-[0.5rem] rounded-full',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  },
+)
+
+function RadioGroupRoot({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn('grid gap-3', className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  size,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item> &
+  VariantProps<typeof radioGroupVariants>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        'border-neutral-gray data-[state=checked]:border-primary  text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        radioGroupVariants({ size }),
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon
+          className={circleIconVariants({ size })}
+          stroke="currentColor"
+          fill="transparent"
+        />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+type RadioGroupProps = ComponentProps<typeof RadioGroupPrimitive.Root> &
+  VariantProps<typeof radioGroupVariants>
+
+type Option = {
+  label: string
+  value: string
+  disabled?: boolean
+  description?: string
+}
+
+type Props = {
+  className?: string
+  options: Option[]
+  defaultValue?: string
+} & RadioGroupProps
+
+export function RadioGroup({ size, className, defaultValue, options, ...props }: Props) {
+  const [selected, setSelected] = useState<string | undefined>()
+
+  const handleContainerClick = (option: Option) => {
+    if (option.description) {
+      const el = document.getElementById(option.value)
+      if (el) el.click()
+    }
+  }
+
+  function handleChangeValue(value: string) {
+    setSelected(value)
+  }
+
+  useEffect(() => {
+    setSelected(defaultValue)
+  }, [defaultValue])
+
+  return (
+    <RadioGroupRoot {...props} defaultValue={defaultValue} onValueChange={handleChangeValue}>
+      {options?.map((option) => (
+        <div
+          key={option.value}
+          className={cn(
+            'flex flex-row items-center gap-[0.5rem]',
+            {
+              'border-1 border-neutral-gray rounded-[0.5rem] px-[0.75rem] min-w-[15rem] py-[0.5rem]':
+                option?.description,
+              'border-neutral-400': selected === option.value,
+            },
+            className,
+          )}
+          onClick={() => handleContainerClick(option)}
+        >
+          <RadioGroupItem
+            size={size}
+            disabled={option.disabled}
+            value={option.value}
+            id={option.value}
+            className={cn({
+              'mt-[-1rem]': option?.description,
+            })}
+          />
+          <div className="flex flex-col">
+            {option.label && (
+              <label htmlFor={option.value} className={cn(labelVariants({ size }))}>
+                {option.label}
+              </label>
+            )}
+            {option.description && (
+              <p className={descriptionVariants({ size })}>{option.description}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </RadioGroupRoot>
+  )
+}

--- a/registry.json
+++ b/registry.json
@@ -150,6 +150,20 @@
           "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/lib/utils.ts"
         }
       ]
+    },
+    "radio-group": {
+      "name": "Radio Group",
+      "dependencies": ["@radix-ui/react-radio-group", "class-variance-authority", "clsx", "tailwind-merge"],
+      "files": [
+        {
+          "path": "components/ui/radio-group.tsx",
+          "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/radio-group/radio-group.tsx"
+        },
+        {
+          "path": "lib/utils.ts",
+          "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/lib/utils.ts"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
fix(checkbox): update label rendering to use <label> for better accessibility
style(checkbox): change border color to neutral-gray for improved design
feat(ui): add @radix-ui/react-radio-group dependency for RadioGroup component

feat(radio-group): add RadioGroup component for better radio button management and styling

This component allows for a customizable radio button group with support for descriptions and various sizes, enhancing the user interface and experience. It also integrates with existing libraries for improved functionality.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-12 22:38:28 UTC

This PR introduces a new RadioGroup component to the UI component library while making accessibility improvements to the existing Checkbox component. The RadioGroup component provides a comprehensive radio button solution with support for multiple sizes (xs, sm, md, lg), descriptions, disabled states, and container click handling. It follows the established pattern in the codebase by leveraging Radix UI primitives (`@radix-ui/react-radio-group`) for accessibility and using class-variance-authority for styling variants.

The RadioGroup component integrates seamlessly with the existing component architecture, featuring the same barrel export pattern, registry system integration, and testing/documentation structure as other components like Button and Checkbox. The implementation includes a higher-level API that accepts an options array, making it easier for developers to use compared to manually composing individual radio items.

Alongside the new component, the PR updates the Checkbox component with two key changes: switching from a `<p>` element to a proper `<label>` element for better semantic markup, and changing the border color from white to neutral-gray for improved visual consistency with the design system.

The changes also include proper dependency management (adding `@radix-ui/react-radio-group` to package.json), component registry updates for CLI tool integration, comprehensive test coverage, and Storybook stories for documentation and interactive examples.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/ui/src/components/ui/radio-group/radio-group.tsx | 2/5 | Implements new RadioGroup component with styling variants but has critical issues with state management and accessibility |
| packages/ui/src/components/ui/checkbox/checkbox.tsx | 2/5 | Updates Checkbox for better accessibility but introduces critical label association bug |
| packages/ui/src/components/ui/radio-group/radio-group.test.tsx | 4/5 | Adds comprehensive test coverage with one potentially brittle DOM traversal test |
| packages/ui/src/components/ui/radio-group/radio-group.stories.tsx | 4/5 | Adds Storybook stories for RadioGroup with minor typo in disabled option value |
| registry.json | 4/5 | Registers RadioGroup component in the component registry with correct metadata and dependencies |
| packages/ui/package.json | 5/5 | Adds required Radix UI dependency for RadioGroup component functionality |
| packages/ui/src/components/ui/radio-group/index.tsx | 5/5 | Standard barrel export file following established component patterns |

</details>

## Confidence score: 2/5

- This PR introduces significant functionality but contains critical accessibility and implementation issues that could cause problems
- Score reflects major concerns in the core RadioGroup and Checkbox implementations including broken label associations and inconsistent state management
- Pay close attention to packages/ui/src/components/ui/radio-group/radio-group.tsx and packages/ui/src/components/ui/checkbox/checkbox.tsx which need fixes before merging

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Component as "RadioGroup Component"
    participant State as "Internal State"
    participant Radix as "@radix-ui/react-radio-group"
    participant DOM

    User->>Component: "Renders RadioGroup with options"
    Component->>State: "Initialize with defaultValue"
    Component->>Radix: "Create RadioGroupRoot"
    Component->>DOM: "Render radio options with labels"
    
    User->>DOM: "Clicks radio option"
    DOM->>Component: "Trigger handleChangeValue()"
    Component->>State: "Update selected state"
    Component->>Radix: "Update RadioGroupPrimitive value"
    Component->>DOM: "Re-render with new selection"
    
    alt User clicks container with description
        User->>DOM: "Clicks option container"
        DOM->>Component: "Trigger handleContainerClick()"
        Component->>DOM: "Programmatically click radio input"
        DOM->>Component: "Trigger handleChangeValue()"
        Component->>State: "Update selected state"
    end
    
    alt Option is disabled
        User->>DOM: "Attempts to click disabled option"
        DOM-->>User: "No action (disabled state)"
    end
```

<!-- /greptile_comment -->