### PR TITLE
chore(ci): update Node.js version from 20 to 22 in CI workflow for compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://npm.pkg.github.com/'
+          registry-url: 'https://registry.npmjs.org/'
 
-      - name: Authenticate to GitHub Packages
-        run: npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
+      - name: Authenticate to npm
+        run: npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -9666,7 +9666,7 @@
     },
     "packages/cli": {
       "name": "@roxygens/ui-startkit",
-      "version": "0.0.2",
+      "version": "0.0.1",
       "dependencies": {
         "commander": "^14.0.0",
         "dotenv": "^17.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roxygens/ui-startkit",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "Adicione componentes reutilizáveis ao seu projeto",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -9,13 +9,14 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs --dts --clean --external chalk --external ora --external prompts --external node-fetch --external execa --external fs-extra"
+    "build": "tsup src/index.ts --format cjs --dts --clean --external chalk --external ora --external prompts --external node-fetch --external execa --external fs-extra && node src/scripts/copy-css.js"
   },
   "bin": {
     "ui-startkit": "./dist/index.js"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,13 +11,6 @@ import chalk from 'chalk'
 
 const program = new Command()
 
-function getNpmToken() {
-  const npmrcPath = path.resolve(process.cwd(), '.npmrc')
-  const npmrc = fs.readFileSync(npmrcPath, 'utf-8')
-  const match = npmrc.match(new RegExp(`^//npm\\.pkg\\.github\\.com/:_authToken=(.+)$`, 'm'))
-  return match ? match[1] : null
-}
-
 // =================================================================
 // COMANDO INIT (ATUALIZADO COM O TEMA DO FIGMA PARA TAILWIND v4)
 // =================================================================
@@ -39,7 +32,7 @@ program
           type: 'text',
           name: 'componentsAlias',
           message: 'Qual alias você quer para os componentes?',
-          initial: '@/components',
+          initial: '@/components/ui',
         },
         {
           type: 'text',
@@ -112,11 +105,7 @@ program
       const REGISTRY_API_URL =
         'https://api.github.com/repos/roxygens/ui-startkit/contents/registry.json'
 
-      const token = getNpmToken()
-
-      const response = await fetch(REGISTRY_API_URL, {
-        headers: { Authorization: `token ${token}` },
-      })
+      const response = await fetch(REGISTRY_API_URL)
 
       const fileData: any = await response.json()
 
@@ -146,9 +135,7 @@ program
       }
 
       for (const file of componentData.files) {
-        const fileResponse = await fetch(file.contentUrl, {
-          headers: { Authorization: `token ${token}` },
-        })
+        const fileResponse = await fetch(file.contentUrl)
 
         if (!fileResponse.ok) {
           throw new Error(`Erro ao baixar arquivo: ${file.path}`)

--- a/packages/cli/src/scripts/copy-css.js
+++ b/packages/cli/src/scripts/copy-css.js
@@ -1,0 +1,21 @@
+import fs from 'fs-extra'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const src = path.resolve(__dirname, '../../../ui/src/index.css')
+const dest = path.resolve(__dirname, '../../../cli/dist/index.css')
+
+async function copyCSS() {
+  try {
+    await fs.copy(src, dest)
+    console.log('✔ index.css copiado de UI para CLI/dist')
+  } catch (err) {
+    console.error('Erro ao copiar index.css:', err)
+    process.exit(1)
+  }
+}
+
+copyCSS()


### PR DESCRIPTION
chore(publish): switch npm registry from GitHub Packages to npm registry for broader accessibility
fix(cli): change package version from 0.0.2 to 0.0.1 to reflect correct release
feat(cli): add CSS copying script to build process for better asset management
refactor(cli): remove GitHub token handling from CLI code to simplify authentication process