### PR TITLE
feat(package.json): add new scripts for local npm publishing and serving

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "publish-cli": "npm publish -w=ui-startkit",
     "serve-npm-local": "npx verdaccio",
     "publish-cli-local": "npm run build-cli && npm publish --registry http://localhost:4873 -w=ui-startkit",
-    "unpublish-cli-local": "npm unpublish nome-do-pacote --registry http://localhost:4873 --force"
+    "unpublish-cli-local": "npm unpublish ui-startkit --registry http://localhost:4873 --force"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "build": "npm run build --workspaces",
     "serve": "npx http-server ./packages/ui/storybook-static",
     "build-cli": "npm run build -w=ui-startkit",
-    "publish-cli": "npm publish -w=ui-startkit"
+    "publish-cli": "npm publish -w=ui-startkit",
+    "serve-npm-local": "npx verdaccio",
+    "publish-cli-local": "npm run build-cli && npm publish --registry http://localhost:4873 -w=ui-startkit",
+    "unpublish-cli-local": "npm unpublish nome-do-pacote --registry http://localhost:4873 --force"
   },
   "keywords": [],
   "author": "",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -66,11 +66,35 @@ program
       spinner.start('Adicionando tema ao CSS...')
 
       const cssPath = path.resolve(__dirname, 'index.css')
-
       const themeConfig = await fs.readFile(cssPath, 'utf-8')
-
       const originalCss = await fs.readFile(options.tailwindCssFile, 'utf-8')
-      await fs.writeFile(options.tailwindCssFile, themeConfig + '\n' + originalCss)
+
+      function mergeCss(base: string, update: string): string {
+        const baseLines = base
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean)
+        const updateLines = update
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean)
+
+        const sameLines = updateLines.filter((line) => baseLines.includes(line)).length
+        const similarity = sameLines / updateLines.length
+
+        if (similarity > 0.9) {
+          const mergedLines = [
+            ...updateLines,
+            ...baseLines.filter((line) => !updateLines.includes(line)),
+          ]
+          return mergedLines.join('\n')
+        }
+
+        return update + '\n' + base
+      }
+
+      const mergedCss = mergeCss(originalCss, themeConfig)
+      await fs.writeFile(options.tailwindCssFile, mergedCss)
       spinner.succeed(`Tema "Skins Games" adicionado a \`${options.tailwindCssFile}\`.`)
 
       spinner.start('Instalando dependências...')
@@ -82,12 +106,7 @@ program
       console.log(chalk.yellow('\n🚨 Lembretes:'))
       console.log(
         chalk.yellow(
-          '  - Certifique-se de que seu `tailwind.config.js` está configurado para o modo escuro (`darkMode: "class"`).',
-        ),
-      )
-      console.log(
-        chalk.yellow(
-          '  - Adicione a fonte "Inter" ao seu projeto para uma correspondência visual perfeita.',
+          '  - Adicione a fonte "Manrope" ao seu projeto para uma correspondência visual perfeita.',
         ),
       )
     } catch (error) {

--- a/packages/ui/src/components/ui/input-otp/input-otp.tsx
+++ b/packages/ui/src/components/ui/input-otp/input-otp.tsx
@@ -7,7 +7,7 @@ const inputOtpVariants = cva(
     text-white placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground  shadow-[0_1px_2px_rgba(0,0,0,0.05)]  border border-[var(--color-neutral-gray)]
     flex w-full text-center min-w-0 rounded-0 bg-transparent text-base shadow-xs 
     transition-[color,box-shadow] outline-none 
-    disabled:cursor-not-allowed disabled:hover:border-none  disabled:opacity-50 md:text-sm disabled:bg-[var(--disabled)] disabled:text-[var(--primary-foreground-disabled)]
+    disabled:cursor-not-allowed disabled:hover:border-none  disabled:opacity-50 disabled:bg-[var(--disabled)] disabled:text-[var(--primary-foreground-disabled)]
 
     hover:border-[var(--primary)] 
 
@@ -18,10 +18,10 @@ const inputOtpVariants = cva(
   {
     variants: {
       size: {
-        xs: 'h-[1.5rem] w-[1.5rem]  text-xs',
+        xs: 'h-[1.5rem] w-[1.5rem] text-xs',
         sm: 'h-[2rem]  w-[2rem] text-sm',
-        md: 'h-[2.25rem]  w-[2.25rem] text-sm',
-        lg: 'h-[2.5rem] w-[2.5rem] text-sm',
+        md: 'h-[2.25rem]  w-[2.25rem] text-base',
+        lg: 'h-[2.5rem] w-[2.5rem] text-lg',
       },
     },
     defaultVariants: {
@@ -103,7 +103,7 @@ export function InputOtp({
   }, [length])
 
   return (
-    <div className="flex gap-0">
+    <div className="flex gap-[0.5rem]">
       {values.map((v, i) => (
         <input
           {...rest}
@@ -113,11 +113,7 @@ export function InputOtp({
           maxLength={1}
           value={v}
           disabled={disabled}
-          className={cn(inputOtpVariants({ size, className }), {
-            'rounded-[0.5rem]': length === 1,
-            'rounded-l-[0.5rem]': i === 0,
-            'rounded-r-[0.5rem]': i === length - 1,
-          })}
+          className={cn(inputOtpVariants({ size, className }))}
           onChange={(e) => handleChange(i, e.target.value)}
           onPaste={(e) => handlePaste(i, e)}
         />

--- a/packages/ui/src/components/ui/input/input.test.tsx
+++ b/packages/ui/src/components/ui/input/input.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
+import { Home } from 'lucide-react'
+
 import { Input } from '.'
 
 describe('Input', () => {
@@ -50,14 +52,14 @@ describe('Input', () => {
       render(<Input size="xs" />)
       const inputElement = screen.getByRole('textbox')
 
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[1.65rem] text-xs')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[1.5rem] text-xs')
     })
 
     it('should apply specified size variant (sm) classes', () => {
       render(<Input size="sm" />)
       const inputElement = screen.getByRole('textbox')
 
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[1.65rem] text-xs')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[2rem] text-sm')
     })
 
     it('should apply specified size variant (md) classes', () => {
@@ -71,7 +73,7 @@ describe('Input', () => {
       render(<Input size="lg" />)
       const inputElement = screen.getByRole('textbox')
 
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-xl')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-lg')
     })
 
     it('should merge additional classNames with variant classes', () => {
@@ -79,7 +81,7 @@ describe('Input', () => {
       const inputElement = screen.getByRole('textbox')
 
       expect(inputElement).toHaveClass('my-custom-class')
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-xl')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-lg')
     })
   })
 
@@ -91,5 +93,31 @@ describe('Input', () => {
 
     ref.current?.focus()
     expect(ref.current).toHaveFocus()
+  })
+
+  it('should render with xs size and icon', () => {
+    render(<Input data-testid="input" size="xs" icon={<Home data-testid="icon" />} />)
+    const input = screen.getByTestId('input')
+    const icon = screen.getByTestId('icon')
+    expect(input).toHaveClass('pl-[1.75rem]')
+    expect(icon).toBeInTheDocument()
+  })
+
+  it('should render with sm size and icon', () => {
+    render(<Input data-testid="input" size="sm" icon={<Home data-testid="icon" />} />)
+    const input = screen.getByTestId('input')
+    expect(input).toHaveClass('pl-[1.875rem]')
+  })
+
+  it('should render with md size and icon', () => {
+    render(<Input data-testid="input" size="md" icon={<Home data-testid="icon" />} />)
+    const input = screen.getByTestId('input')
+    expect(input).toHaveClass('pl-[2rem]')
+  })
+
+  it('should render with lg size and icon', () => {
+    render(<Input data-testid="input" size="lg" icon={<Home data-testid="icon" />} />)
+    const input = screen.getByTestId('input')
+    expect(input).toHaveClass('pl-[2.25rem]')
   })
 })

--- a/packages/ui/src/components/ui/input/input.tsx
+++ b/packages/ui/src/components/ui/input/input.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
+import { type ComponentProps, forwardRef } from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const inputVariants = cva(
   `
     file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground  shadow-[0_1px_2px_rgba(0,0,0,0.05)]  border border-[var(--secondary-border)]
-    flex h-9 w-full min-w-0 rounded-[0.25rem] bg-neutral-900 px-3 py-1 text-base shadow-xs 
+    flex h-9 w-full min-w-0 bg-neutral-900 px-3 py-1 text-base shadow-xs 
     transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0  file:text-sm 
     file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm disabled:bg-[var(--disabled)] disabled:text-[var(--primary-foreground-disabled)]
 
@@ -20,10 +20,10 @@ const inputVariants = cva(
   {
     variants: {
       size: {
-        xs: 'px-[0.5rem] h-[1.65rem] text-xs',
-        sm: 'px-[0.5rem] h-[1.65rem] text-xs',
+        xs: 'px-[0.5rem] h-[1.5rem] text-xs',
+        sm: 'px-[0.5rem] h-[2rem] text-sm',
         md: 'px-[0.5rem] h-[2.25rem] text-base',
-        lg: 'px-[0.5rem] h-[2.5rem] text-xl',
+        lg: 'px-[0.5rem] h-[2.5rem] text-lg',
       },
     },
     defaultVariants: {
@@ -34,16 +34,48 @@ const inputVariants = cva(
 
 type OtherProps = {
   disabled?: boolean
+  className?: string
+  icon?: React.ReactNode
 }
 
-type InputProps = Omit<React.ComponentProps<'input'>, 'size'> &
+type InputProps = Omit<ComponentProps<'input'>, 'size'> &
   VariantProps<typeof inputVariants> &
   OtherProps
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, size, ...props }, ref) => {
+const iconVariants = cva(
+  'absolute left-[0.5rem] flex items-center pointer-events-none text-muted-foreground',
+  {
+    variants: {
+      size: {
+        xs: '[&_svg]:h-[0.75rem] [&_svg]:w-[0.75rem]',
+        sm: '[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]',
+        md: '[&_svg]:h-[1rem] [&_svg]:w-[1rem]',
+        lg: '[&_svg]:h-[1.125rem] [&_svg]:h-[1.125rem]',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  },
+)
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, size, icon, ...props }, ref) => {
     return (
-      <input type={type} className={cn(inputVariants({ size, className }))} ref={ref} {...props} />
+      <div className="relative flex items-center w-full">
+        {!!icon && <span className={cn(iconVariants({ size }))}>{icon}</span>}
+        <input
+          type={type}
+          className={cn(inputVariants({ size, className }), {
+            'pl-[1.75rem]': icon && size === 'xs',
+            'pl-[1.875rem]': icon && size === 'sm',
+            'pl-[2rem]': icon && size === 'md',
+            'pl-[2.25rem]': icon && size === 'lg',
+          })}
+          ref={ref}
+          {...props}
+        />
+      </div>
     )
   },
 )

--- a/packages/ui/src/components/ui/input/input.tsx
+++ b/packages/ui/src/components/ui/input/input.tsx
@@ -50,7 +50,7 @@ const iconVariants = cva(
         xs: '[&_svg]:h-[0.75rem] [&_svg]:w-[0.75rem]',
         sm: '[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]',
         md: '[&_svg]:h-[1rem] [&_svg]:w-[1rem]',
-        lg: '[&_svg]:h-[1.125rem] [&_svg]:h-[1.125rem]',
+        lg: '[&_svg]:h-[1.125rem] [&_svg]:w-[1.125rem]',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
feat(cli): implement CSS merging logic to avoid duplication and improve efficiency
fix(cli): update reminder message to reflect the correct font to use
style(input): adjust input component styles for better consistency and clarity
feat(input): add support for icons in input components to enhance usability

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-30 15:36:34 UTC

<h3>Summary</h3>
This PR implements significant improvements to the UI startkit focusing on CLI enhancements and input component refinements. The changes span across four main areas:

**CLI Improvements**: The most substantial change is the implementation of intelligent CSS merging logic in the CLI tool. Previously, running the initialization command multiple times would duplicate CSS content, creating bloated stylesheets. The new `mergeCss` function analyzes CSS similarity using a 90% threshold - when new CSS content is highly similar to existing content, it merges them intelligently by combining unique lines from both sources. When content differs significantly, it appends the new CSS to preserve distinct styles. Additionally, the font recommendation has been updated from 'Inter' to 'Manrope', reflecting an evolution in the design system's typography choices.

**Input Component Enhancement**: The input component has been significantly enhanced with icon support, a common UX pattern for modern web applications. The component now uses a container div with relative positioning to accommodate absolutely positioned icons, while maintaining backward compatibility with existing variants. The implementation includes conditional padding adjustments based on icon presence and size, ensuring proper spacing and visual balance.

**Styling Refinements**: Both input and input-otp components received styling updates for better consistency. The regular input component had its hardcoded border-radius removed and size variant dimensions refined. The OTP input component moved away from tightly-connected input fields to spaced individual fields, improving accessibility and visual clarity while standardizing font size progressions across variants.

**Development Workflow**: New npm scripts were added to support local package testing using Verdaccio, enabling developers to test the CLI publishing workflow locally before releasing to the public registry.

These changes integrate well with the existing component architecture, maintaining the established patterns of using class-variance-authority for styling variants while extending functionality in a backward-compatible manner.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/cli/src/index.ts | 4/5 | Implements CSS merging logic with 90% similarity threshold and updates font recommendation to Manrope |
| package.json | 2/5 | Adds local npm registry scripts but contains hardcoded placeholder package name in unpublish script |
| packages/ui/src/components/ui/input/input.tsx | 4/5 | Adds icon support with container wrapper and conditional padding, plus styling refinements |
| packages/ui/src/components/ui/input-otp/input-otp.tsx | 4/5 | Updates styling for better consistency with spaced inputs and standardized font sizes |

</details>

## Confidence score: 3/5

- This PR introduces useful functionality but has one critical issue that prevents safe merging
- Score lowered due to hardcoded placeholder text in the unpublish script that will cause runtime errors
- Pay close attention to package.json which contains a critical bug in the unpublish-cli-local script

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "npm/CLI" as CLI
    participant "package.json" as Package
    participant "Verdaccio Server" as Local
    participant "Input Component" as Input
    participant "CSS Merger" as Merger

    User->>CLI: "npm run serve-npm-local"
    CLI->>Local: Start Verdaccio server on localhost:4873
    Local-->>User: Local npm registry running

    User->>CLI: "npm run publish-cli-local"
    CLI->>Package: Execute build-cli script
    Package->>CLI: Build ui-startkit package
    CLI->>Local: Publish to local registry
    Local-->>User: Package published locally

    User->>CLI: "ui-startkit init"
    CLI->>User: Prompt for CSS file path
    User-->>CLI: Provide globals.css path
    CLI->>User: Prompt for components alias
    User-->>CLI: Provide alias path
    CLI->>Merger: Read existing CSS file
    Merger->>Merger: Calculate similarity between CSS files
    Merger->>Merger: Merge CSS avoiding duplicates
    Merger-->>CLI: Return merged CSS content
    CLI->>Package: Write merged CSS to file
    CLI-->>User: "Theme added successfully"

    User->>CLI: "ui-startkit add input"
    CLI->>Input: Fetch component from registry
    Input-->>CLI: Return component files
    CLI->>Input: Install input component with icon support
    CLI-->>User: "Input component installed with icon support"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->