### PR TITLE
docs(cli): add README.md for ui-startkit CLI with installation and us…

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,294 @@
+[<img src="https://flagcdn.com/w20/br.png" alt="Bandeira do Brasil" width="20"> Leia em: 🇧🇷 Português](README.pt-br.md)
+
+# ui-startkit
+
+Welcome to `ui-startkit`! 🎨
+A collection of **reusable, accessible, and customizable UI components**, inspired by the philosophy of [Shadcn/ui](https://ui.shadcn.com/).
+
+Unlike traditional libraries, `ui-startkit` provides a **CLI** that lets you copy components directly into your project, giving you **full control over the code**.
+
+---
+
+## 🌟 Features
+
+*   **You own the code:** All components are copied to your source code.
+*   **Tailwind CSS:** Modern and fully customizable styling.
+*   **Radix UI:** High-quality and accessible primitives.
+*   **Simple usage:** Add components with a single CLI command.
+
+---
+
+## 🚀 Installation and Usage
+
+Before you start, your project must have:
+
+*   React
+*   TypeScript
+*   Tailwind CSS
+
+### Initialize `ui-startkit`
+
+```bash
+npx ui-startkit@latest init
+```
+
+This sets up the base styles and dependencies in your project.
+
+### Add components
+
+```bash
+npx ui-startkit@latest add <component-name>
+```
+
+**Example:** Adding the `Button` component:
+
+```bash
+npx ui-startkit@latest add button
+```
+
+The component will be created at `src/components/ui/button.tsx`, and you can use it like this:
+
+```tsx
+import { Button } from '@/components/ui/button'
+
+export function MyComponent() {
+  return <Button>Click me</Button>
+}
+```
+
+---
+
+## 📂 Available Components
+
+### Avatar
+
+```bash
+npx ui-startkit@latest add avatar
+```
+
+### Badge
+
+```bash
+npx ui-startkit@latest add badge
+```
+
+### Breadcrumb
+
+```bash
+npx ui-startkit@latest add breadcrumb
+```
+
+### Button
+
+```bash
+npx ui-startkit@latest add button
+```
+
+### Card
+
+```bash
+npx ui-startkit@latest add card
+```
+
+### Checkbox
+
+```bash
+npx ui-startkit@latest add checkbox
+```
+
+### Date Picker
+
+```bash
+npx ui-startkit@latest add date-picker
+```
+
+### Input
+
+```bash
+npx ui-startkit@latest add input
+```
+
+### Input OTP
+
+```bash
+npx ui-startkit@latest add input-otp
+```
+
+### List
+
+```bash
+npx ui-startkit@latest add list
+```
+
+### Pagination
+
+```bash
+npx ui-startkit@latest add pagination
+```
+
+### Progress Bar
+
+```bash
+npx ui-startkit@latest add progress-bar
+```
+
+### Radio Group
+
+```bash
+npx ui-startkit@latest add radio-group
+```
+
+### Score Bar
+
+```bash
+npx ui-startkit@latest add score-bar
+```
+
+### Select
+
+```bash
+npx ui-startkit@latest add select
+```
+
+### Switch
+
+```bash
+npx ui-startkit@latest add switch
+```
+
+### Table
+
+```bash
+npx ui-startkit@latest add table
+```
+
+### Tabs
+
+```bash
+npx ui-startkit@latest add tabs
+```
+
+### Tooltip
+
+```bash
+npx ui-startkit@latest add tooltip
+```
+
+> 💡 Copy and run the commands directly in your terminal to add the desired components.
+
+---
+
+## 🏗️ Development Workflow
+
+### Set up the environment
+
+```bash
+git clone https://github.com/roxygens/ui-startkit.git
+cd ui-startkit
+npm install
+```
+
+You will have the **complete monorepo** with:
+
+*   `packages/ui` → all components
+*   `packages/cli` → the CLI tool
+
+### Run the documentation app
+
+```bash
+npm run dev
+# or
+npm run storybook --workspace=ui
+```
+
+Access: [http://localhost:6006](http://localhost:6006) to view the components in real-time.
+
+### Create or edit components
+
+1.  Add the component files to their specific folder inside `packages/ui/src/components/ui/`.
+    For example, for the Avatar component, the file structure in `packages/ui/src/components/ui/avatar/` would be:
+
+    *   **`avatar.tsx`**: This is the main file containing the component's logic, JSX structure, and props. This is where the component is actually implemented.
+
+    *   **`avatar.test.tsx`**: The file for unit and integration tests. Here you write tests using Vitest to ensure the component behaves as expected in different scenarios and doesn't break with future changes.
+
+    *   **`avatar.stories.tsx`**: Defines the "stories" for Storybook. Each story represents a visual variation of the component (e.g., with an image, without an image, small size), serving as interactive documentation and an isolated development environment.
+
+    *   **`index.tsx`**: Acts as the entry point (or "barrel file") for the component's directory. Its main function is to export the main component and any related types or hooks, allowing for cleaner imports elsewhere in the project (e.g., `import { Avatar } from '.../avatar'` instead of `.../avatar/avatar`).
+
+2.  Import helpers from `lib/utils.ts` if needed.
+3.  Test in Storybook before publishing.
+
+### Add a component to the CLI
+
+1.  Open `registry.json` at the root of the project.
+2.  Add an entry for your component following the existing pattern:
+
+```json
+"my-component": {
+  "name": "My Component",
+  "dependencies": ["clsx", "tailwind-merge"],
+  "files": [
+    {
+      "path": "components/ui/my-component.tsx",
+      "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/my-component/my-component.tsx"
+    },
+    {
+      "path": "lib/utils.ts",
+      "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/lib/utils.ts"
+    }
+  ]
+}
+```
+
+> **Note:** Only add the `lib/utils.ts` file and the `clsx` and `tailwind-merge` dependencies if the component actually uses these utilities. Any other external dependencies should be added to the corresponding `dependencies` array.
+
+### Contributing
+
+```bash
+git checkout main
+git pull
+git checkout -b feature/new-component
+git commit -m "feat: adds the new component"
+git push origin feature/new-component
+```
+
+Open a Pull Request on GitHub. All PR messages must be written in **English**.
+
+---
+
+## 📄 Monorepo Structure
+
+```
+ui-startkit/
+├─ packages/
+│  ├─ ui/          # component source code
+│  └─ cli/         # CLI for adding components
+├─ registry.json    # component registry for the CLI
+└─ package.json     # monorepo scripts and dependencies
+```
+
+---
+
+## 📌 Available Scripts
+
+```bash
+npm run dev           # runs Storybook
+npm run test          # runs tests
+npm run build         # builds the monorepo
+npm run serve         # serves the Storybook build
+npm run build-cli   # builds the CLI
+npm run publish-cli # publishes the CLI
+```
+
+---
+
+## 📖 Documentation
+
+To see all components and examples, visit: [https://ui.roxygens.com](https://ui.roxygens.com)
+
+---
+
+## 📝 License
+
+This project is licensed under the [MIT License](LICENSE)

--- a/packages/cli/README.pt-br.md
+++ b/packages/cli/README.pt-br.md
@@ -1,0 +1,296 @@
+[<img src="https://flagcdn.com/w20/us.png" alt="Bandeira dos EUA" width="20">  Read in: 🇺🇸 English](README.md)
+
+# ui-startkit
+
+Bem-vindo ao `ui-startkit`! 🎨
+Uma coleção de **componentes de UI reutilizáveis, acessíveis e customizáveis**, inspirados na filosofia do [Shadcn/ui](https://ui.shadcn.com/).
+
+Diferente de bibliotecas tradicionais, `ui-startkit` fornece uma **CLI** que permite copiar os componentes diretamente para o seu projeto, garantindo **total controle sobre o código**.
+
+---
+
+## 🌟 Características
+
+* **Você é o dono do código:** Todos os componentes vão para o seu código-fonte.
+* **Tailwind CSS:** Estilização moderna e totalmente customizável.
+* **Radix UI:** Primitivos de alta qualidade e acessíveis.
+* **Uso simples:** Adicione componentes com um único comando CLI.
+
+---
+
+## 🚀 Instalação e Uso
+
+Antes de começar, seu projeto deve ter:
+
+* React
+* TypeScript
+* Tailwind CSS
+
+### Inicializar o `ui-startkit`
+
+```bash
+npx ui-startkit@latest init
+```
+
+Isso configura os estilos base e dependências no seu projeto.
+
+### Adicionar componentes
+
+```bash
+npx ui-startkit@latest add <nome-do-componente>
+```
+
+**Exemplo:** Adicionando o componente `Button`:
+
+```bash
+npx ui-startkit@latest add button
+```
+
+O componente será criado em `src/components/ui/button.tsx` e você poderá usá-lo assim:
+
+```tsx
+import { Button } from '@/components/ui/button'
+
+export function MeuComponente() {
+  return <Button>Clique aqui</Button>
+}
+```
+
+---
+
+## 📂 Instalação rápida de todos os componentes
+
+### Avatar
+
+```bash
+npx ui-startkit@latest add avatar
+```
+
+### Badge
+
+```bash
+npx ui-startkit@latest add badge
+```
+
+### Breadcrumb
+
+```bash
+npx ui-startkit@latest add breadcrumb
+```
+
+### Button
+
+```bash
+npx ui-startkit@latest add button
+```
+
+### Card
+
+```bash
+npx ui-startkit@latest add card
+```
+
+### Checkbox
+
+```bash
+npx ui-startkit@latest add checkbox
+```
+
+### Date Picker
+
+```bash
+npx ui-startkit@latest add date-picker
+```
+
+### Input
+
+```bash
+npx ui-startkit@latest add input
+```
+
+### Input OTP
+
+```bash
+npx ui-startkit@latest add input-otp
+```
+
+### List
+
+```bash
+npx ui-startkit@latest add list
+```
+
+### Pagination
+
+```bash
+npx ui-startkit@latest add pagination
+```
+
+### Progress Bar
+
+```bash
+npx ui-startkit@latest add progress-bar
+```
+
+### Radio Group
+
+```bash
+npx ui-startkit@latest add radio-group
+```
+
+### Score Bar
+
+```bash
+npx ui-startkit@latest add score-bar
+```
+
+### Select
+
+```bash
+npx ui-startkit@latest add select
+```
+
+### Switch
+
+```bash
+npx ui-startkit@latest add switch
+```
+
+### Table
+
+```bash
+npx ui-startkit@latest add table
+```
+
+### Tabs
+
+```bash
+npx ui-startkit@latest add tabs
+```
+
+### Tooltip
+
+```bash
+npx ui-startkit@latest add tooltip
+```
+
+
+> 💡 Copie e execute os comandos diretamente no terminal para adicionar os componentes desejados.
+
+---
+
+## 🏗️ Fluxo de Desenvolvimento
+
+### Preparar o ambiente
+
+```bash
+git clone https://github.com/roxygens/ui-startkit.git
+cd ui-startkit
+npm install
+```
+
+Você terá o **monorepo completo** com:
+
+* `packages/ui` → todos os componentes
+* `packages/cli` → ferramenta CLI
+
+### Rodar a aplicação de documentação
+
+```bash
+npm run dev
+# ou
+npm run storybook --workspace=ui
+```
+
+Acesse: [http://localhost:6006](http://localhost:6006) para visualizar os componentes em tempo real.
+
+### Criar ou editar componentes
+
+1.  Adicione os arquivos do componente em sua pasta específica dentro de `packages/ui/src/components/ui/`.
+    Por exemplo, para o componente Avatar, a estrutura de arquivos em `packages/ui/src/components/ui/avatar/` seria:
+
+    *   **`avatar.tsx`**: Este é o arquivo principal que contém a lógica, a estrutura JSX e as `props` do componente. É aqui que o componente é de fato implementado.
+
+    *   **`avatar.test.tsx`**: Arquivo para os testes unitários e de integração. Aqui você escreve testes usando Vitest para garantir que o componente se comporte como esperado em diferentes cenários e não quebre com futuras alterações.
+
+    *   **`avatar.stories.tsx`**: Define as "histórias" para o Storybook. Cada história representa uma variação visual do componente (ex: com imagem, sem imagem, tamanho pequeno), servindo como documentação interativa e um ambiente de desenvolvimento isolado.
+
+    *   **`index.tsx`**: Atua como o ponto de entrada (ou "barrel file") para o diretório do componente. Sua principal função é exportar o componente principal e quaisquer tipos ou hooks relacionados, permitindo importações mais limpas em outras partes do projeto (ex: `import { Avatar } from '.../avatar'` em vez de `.../avatar/avatar`).
+
+2.  Importe helpers do `lib/utils.ts` se necessário.
+3.  Teste no Storybook antes de publicar.
+
+### Adicionar componente à CLI
+
+1. Abra `registry.json` na raiz do projeto.
+2. Adicione uma entrada para seu componente seguindo o padrão existente:
+
+```json
+"meu-componente": {
+  "name": "Meu Componente",
+  "dependencies": ["clsx", "tailwind-merge"],
+  "files": [
+    {
+      "path": "components/ui/meu-componente.tsx",
+      "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/meu-componente/meu-componente.tsx"
+    },
+    {
+      "path": "lib/utils.ts",
+      "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/lib/utils.ts"
+    }
+  ]
+}
+```
+
+
+> **Observação:** Apenas adicione o arquivo `lib/utils.ts` e as dependências `clsx` e `tailwind-merge` se o componente realmente utilizar esses utilitários. Qualquer outra dependência externa deve ser adicionada ao array `dependencies` correspondente.
+
+### Contribuindo
+
+```bash
+git checkout main
+git pull
+git checkout -b feature/new-component
+git commit -m "feat: adds the new component"
+git push origin feature/new-component
+```
+
+Abra um Pull Request no GitHub. Todas as mensagens de PR devem ser escritas em **inglês**.
+
+---
+
+## 📄 Estrutura do Monorepo
+
+```
+ui-startkit/
+├─ packages/
+│  ├─ ui/          # código-fonte dos componentes
+│  └─ cli/         # CLI para adicionar componentes
+├─ registry.json    # registro de componentes para a CLI
+└─ package.json     # scripts e dependências do monorepo
+```
+
+---
+
+## 📌 Scripts disponíveis
+
+```bash
+npm run dev           # roda Storybook
+npm run test          # executa testes
+npm run build         # build do monorepo
+npm run serve         # serve Storybook build
+npm run build-cli     # build da CLI
+npm run publish-cli   # publica a CLI
+```
+
+---
+
+## 📖 Documentação
+
+Para ver todos os componentes e exemplos, acesse: [https://ui.roxygens.com](https://ui.roxygens.com)
+
+---
+
+## 📝 Licença
+
+Este projeto está licenciado sob a [Licença MIT](LICENSE)

--- a/packages/cli/src/scripts/copy-readme.js
+++ b/packages/cli/src/scripts/copy-readme.js
@@ -6,10 +6,10 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 const src = path.resolve(__dirname, '../../../../README.md')
-const dest = path.resolve(__dirname, '../../../cli/dist/README.md')
+const dest = path.resolve(__dirname, '../../../cli/README.md')
 
 const srcPt = path.resolve(__dirname, '../../../../README.pt-br.md')
-const destPt = path.resolve(__dirname, '../../../cli/dist/README.pt-br.md')
+const destPt = path.resolve(__dirname, '../../../cli/README.pt-br.md')
 
 async function copyREADME() {
   try {


### PR DESCRIPTION
…age instructions

This commit introduces a comprehensive README.md file for the ui-startkit CLI, detailing features, installation steps, available components, development workflow, and contribution guidelines to enhance user understanding and onboarding.

docs(cli): add Brazilian Portuguese README for ui-startkit to support local users
chore(copy-readme.js): update paths for README files to reflect new structure

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 02:49:36 UTC

<h3>Summary</h3>
This PR introduces comprehensive documentation for the ui-startkit CLI package by adding detailed README files in both English and Portuguese. The main change adds `packages/cli/README.md`, which provides complete documentation covering CLI features, installation instructions, usage examples for all available UI components, development workflow, and contribution guidelines. This documentation serves as the primary entry point for developers using the CLI tool to integrate UI components into their projects.

The Portuguese README (`packages/cli/README.pt-br.md`) is a complete translation that maintains the same structure and content, making the project accessible to Brazilian Portuguese-speaking developers. Both README files include detailed component listings that match the registry.json structure, installation commands using `npx ui-startkit@latest add [component]`, and comprehensive development setup instructions.

Additionally, the PR updates the `copy-readme.js` script to align with the new CLI package structure, changing the destination paths to copy README files directly to `packages/cli/` instead of a `dist/` subdirectory. This change reflects a reorganization of the CLI build process to make documentation immediately available at the package root level.

These changes enhance the developer experience by providing clear, comprehensive documentation that was previously missing from the CLI package, making it easier for users to understand how to install, use, and contribute to the ui-startkit project.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/cli/README.md | 5/5 | Added comprehensive English documentation with installation instructions, component listings, and development workflow |
| packages/cli/README.pt-br.md | 5/5 | Added complete Portuguese translation of CLI documentation for Brazilian developers |
| packages/cli/src/scripts/copy-readme.js | 4/5 | Updated file paths to copy README files directly to CLI package root instead of dist subdirectory |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it primarily adds documentation without affecting core functionality
- Score reflects that changes are documentation-focused with minimal code modifications that don't impact critical system behavior
- The copy-readme.js file has a minor console message inconsistency but doesn't affect functionality

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->