### PR TITLE
test(checkbox): update checkbox test cases to use standardized text sizes for better consistency

### DIFF
--- a/packages/ui/src/components/ui/checkbox/checkbox.test.tsx
+++ b/packages/ui/src/components/ui/checkbox/checkbox.test.tsx
@@ -83,22 +83,22 @@ describe('Checkbox', () => {
       switch (size) {
         case 'xs':
           expect(checkbox).toHaveClass('h-3 w-3')
-          expect(label).toHaveClass('text-[0.75rem]')
+          expect(label).toHaveClass('text-xs leading-[1.2] tracking-[0.005rem]')
           expect(description).toHaveClass('text-[0.625rem]')
           break
         case 'sm':
           expect(checkbox).toHaveClass('h-3.5 w-3.5')
-          expect(label).toHaveClass('text-[0.8125rem]')
+          expect(label).toHaveClass('text-sm leading-[1.3] tracking-[0.006rem]')
           expect(description).toHaveClass('text-[0.6875rem]')
           break
         case 'md':
           expect(checkbox).toHaveClass('h-4 w-4')
-          expect(label).toHaveClass('text-[0.875rem]')
+          expect(label).toHaveClass('text-md leading-[1.5] tracking-[0.007rem]')
           expect(description).toHaveClass('text-[0.75rem]')
           break
         case 'lg':
           expect(checkbox).toHaveClass('h-5 w-5')
-          expect(label).toHaveClass('text-[1rem]')
+          expect(label).toHaveClass('text-lg leading-[1.6] tracking-[0.01rem]')
           expect(description).toHaveClass('text-[0.875rem]')
           break
       }

--- a/packages/ui/src/components/ui/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox/checkbox.tsx
@@ -8,7 +8,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 const checkboxVariants = cva(
   `
-    peer group shrink-0 rounded-[0.19rem] border border-neutral-gray shadow-xs mt-[0.15rem]
+    peer group shrink-0  border border-neutral-gray shadow-xs 
     transition-shadow outline-none 
     data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground 
     dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary 
@@ -34,10 +34,10 @@ const checkboxVariants = cva(
 const labelVariants = cva('text-white font-normal', {
   variants: {
     size: {
-      xs: 'text-[0.75rem] leading-[1.2] tracking-[0.005rem]',
-      sm: 'text-[0.8125rem] leading-[1.3] tracking-[0.006rem]',
-      md: 'text-[0.875rem] leading-[1.5] tracking-[0.007rem]',
-      lg: 'text-[1rem] leading-[1.6] tracking-[0.01rem]',
+      xs: 'text-xs leading-[1.2] tracking-[0.005rem]',
+      sm: 'text-sm leading-[1.3] tracking-[0.006rem]',
+      md: 'text-md leading-[1.5] tracking-[0.007rem]',
+      lg: 'text-lg leading-[1.6] tracking-[0.01rem]',
     },
   },
   defaultVariants: {
@@ -88,8 +88,8 @@ function Checkbox({ className, size, label, description, ...props }: Props) {
 
   return (
     <div
-      className={cn('flex flex-row place-items-start gap-[0.5rem]', {
-        'border-1 border-neutral-gray rounded-[0.25rem] px-[0.75rem] min-w-[15rem] py-[0.5rem]':
+      className={cn('flex flex-row items-center place-items-start gap-[0.5rem]', {
+        'items-start border-1 border-neutral-gray  px-[0.75rem] min-w-[15rem] py-[0.5rem]':
           description,
         'border-neutral-400': checked || props?.checked,
       })}
@@ -114,7 +114,15 @@ function Checkbox({ className, size, label, description, ...props }: Props) {
 
       <div className="flex flex-col">
         {label && (
-          <label htmlFor={props?.id} className={labelVariants({ size })}>
+          <label
+            htmlFor={props?.id}
+            className={cn(labelVariants({ size }), {
+              'mt-[-1px]': description && size === 'xs',
+              'mt-[-2px]': description && size === 'sm',
+              'mt-[-3px]': description && size === 'md',
+              'mt-[-4px]': description && size === 'lg',
+            })}
+          >
             {label}
           </label>
         )}

--- a/packages/ui/src/components/ui/input-otp/input-otp.tsx
+++ b/packages/ui/src/components/ui/input-otp/input-otp.tsx
@@ -4,24 +4,21 @@ import { cn } from '@/lib/utils'
 
 const inputOtpVariants = cva(
   `
-    text-white placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground  shadow-[0_1px_2px_rgba(0,0,0,0.05)]  border border-[var(--color-neutral-gray)]
-    flex w-full text-center min-w-0 rounded-0 bg-transparent text-base shadow-xs 
+    text-white placeholder:text-neutral-500  shadow-[0_1px_2px_rgba(0,0,0,0.05)]  border border-[var(--color-neutral-gray)]
+    flex w-full text-center min-w-0 rounded-0 bg-background font-normal leading-[140%]shadow-xs 
     transition-[color,box-shadow] outline-none 
     disabled:cursor-not-allowed disabled:hover:border-none  disabled:opacity-50 disabled:bg-[var(--disabled)] disabled:text-[var(--primary-foreground-disabled)]
-
     hover:border-[var(--primary)] 
-
     focus:border-[var(--primary)] 
-
     aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive
   `,
   {
     variants: {
       size: {
         xs: 'h-[1.5rem] w-[1.5rem] text-xs',
-        sm: 'h-[2rem]  w-[2rem] text-sm',
-        md: 'h-[2.25rem]  w-[2.25rem] text-base',
-        lg: 'h-[2.5rem] w-[2.5rem] text-lg',
+        sm: 'h-[2rem]  w-[2rem] text-xs',
+        md: 'h-[2.25rem]  w-[2.25rem] text-sm',
+        lg: 'h-[2.5rem] w-[2.5rem] text-sm',
       },
     },
     defaultVariants: {

--- a/packages/ui/src/components/ui/input/input.stories.tsx
+++ b/packages/ui/src/components/ui/input/input.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof Input>
 
 export const Default: Story = {
   args: {
-    placeholder: 'Placeholder',
     size: 'md',
+    placeholder: 'Placeholder',
   },
 }

--- a/packages/ui/src/components/ui/input/input.test.tsx
+++ b/packages/ui/src/components/ui/input/input.test.tsx
@@ -45,7 +45,7 @@ describe('Input', () => {
       render(<Input />)
       const inputElement = screen.getByRole('textbox')
 
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.25rem] text-base')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.25rem] text-sm')
     })
 
     it('should apply specified size variant (xs) classes', () => {
@@ -59,21 +59,21 @@ describe('Input', () => {
       render(<Input size="sm" />)
       const inputElement = screen.getByRole('textbox')
 
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[2rem] text-sm')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[2rem] text-xs')
     })
 
     it('should apply specified size variant (md) classes', () => {
       render(<Input size="md" />)
       const inputElement = screen.getByRole('textbox')
 
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.25rem] text-base')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.25rem] text-sm')
     })
 
     it('should apply specified size variant (lg) classes', () => {
       render(<Input size="lg" />)
       const inputElement = screen.getByRole('textbox')
 
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-lg')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-sm')
     })
 
     it('should merge additional classNames with variant classes', () => {
@@ -81,7 +81,7 @@ describe('Input', () => {
       const inputElement = screen.getByRole('textbox')
 
       expect(inputElement).toHaveClass('my-custom-class')
-      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-lg')
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-sm')
     })
   })
 
@@ -106,18 +106,77 @@ describe('Input', () => {
   it('should render with sm size and icon', () => {
     render(<Input data-testid="input" size="sm" icon={<Home data-testid="icon" />} />)
     const input = screen.getByTestId('input')
-    expect(input).toHaveClass('pl-[1.875rem]')
+    expect(input).toHaveClass('pl-[1.75rem]')
   })
 
   it('should render with md size and icon', () => {
     render(<Input data-testid="input" size="md" icon={<Home data-testid="icon" />} />)
     const input = screen.getByTestId('input')
-    expect(input).toHaveClass('pl-[2rem]')
+    expect(input).toHaveClass('pl-[1.875rem]')
   })
 
   it('should render with lg size and icon', () => {
     render(<Input data-testid="input" size="lg" icon={<Home data-testid="icon" />} />)
     const input = screen.getByTestId('input')
-    expect(input).toHaveClass('pl-[2.25rem]')
+    expect(input).toHaveClass('pl-[1.875rem]')
+  })
+
+  it('should render with xs size and icon applying iconVariants', () => {
+    render(<Input data-testid="input" size="xs" icon={<Home data-testid="icon" />} />)
+    const icon = screen.getByTestId('icon')
+    expect(icon.parentElement).toHaveClass('[&_svg]:h-[0.75rem] [&_svg]:w-[0.75rem]')
+  })
+
+  it('should render with sm size and icon applying iconVariants', () => {
+    render(<Input data-testid="input" size="sm" icon={<Home data-testid="icon" />} />)
+    const icon = screen.getByTestId('icon')
+    expect(icon.parentElement).toHaveClass('[&_svg]:h-[0.75rem] [&_svg]:w-[0.75rem]')
+  })
+
+  it('should render with md size and icon applying iconVariants', () => {
+    render(<Input data-testid="input" size="md" icon={<Home data-testid="icon" />} />)
+    const icon = screen.getByTestId('icon')
+    expect(icon.parentElement).toHaveClass('[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]')
+  })
+
+  it('should render with lg size and icon applying iconVariants', () => {
+    render(<Input data-testid="input" size="lg" icon={<Home data-testid="icon" />} />)
+    const icon = screen.getByTestId('icon')
+    expect(icon.parentElement).toHaveClass('[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]')
+  })
+
+  it('should render prefix with xs size and correct variant classes', () => {
+    render(<Input data-testid="input" size="xs" prefix="R$" />)
+    const prefix = screen.getByText('R$')
+    expect(prefix).toHaveClass('text-xs')
+    expect(prefix).toHaveClass('absolute')
+  })
+
+  it('should render prefix with sm size and correct variant classes', () => {
+    render(<Input data-testid="input" size="sm" prefix="R$" />)
+    const prefix = screen.getByText('R$')
+    expect(prefix).toHaveClass('text-xs')
+    expect(prefix).toHaveClass('absolute')
+  })
+
+  it('should render prefix with md size and correct variant classes', () => {
+    render(<Input data-testid="input" size="md" prefix="R$" />)
+    const prefix = screen.getByText('R$')
+    expect(prefix).toHaveClass('text-sm')
+    expect(prefix).toHaveClass('absolute')
+  })
+
+  it('should render prefix with lg size and correct variant classes', () => {
+    render(<Input data-testid="input" size="lg" prefix="R$" />)
+    const prefix = screen.getByText('R$')
+    expect(prefix).toHaveClass('text-sm')
+    expect(prefix).toHaveClass('absolute')
+  })
+
+  it('should apply dynamic padding-left when prefix is present', () => {
+    render(<Input data-testid="input" prefix="R$" />)
+    const input = screen.getByTestId('input')
+    const style = input.getAttribute('style') || ''
+    expect(style.includes('padding-left')).toBe(true)
   })
 })

--- a/packages/ui/src/components/ui/input/input.tsx
+++ b/packages/ui/src/components/ui/input/input.tsx
@@ -1,29 +1,25 @@
-import { type ComponentProps, forwardRef } from 'react'
+'use client'
+import { type ComponentProps, forwardRef, useRef, useLayoutEffect, useState } from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const inputVariants = cva(
   `
-    file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground  shadow-[0_1px_2px_rgba(0,0,0,0.05)]  border border-[var(--secondary-border)]
-    flex h-9 w-full min-w-0 bg-neutral-900 px-3 py-1 text-base shadow-xs 
-    transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0  file:text-sm 
-    file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm disabled:bg-[var(--disabled)] disabled:text-[var(--primary-foreground-disabled)]
-
-    text-white 
-
+    text-white placeholder:text-neutral-500 selection:bg-primary selection:text-primary-foreground  shadow-[0_1px_2px_rgba(0,0,0,0.05)]  border border-[var(--secondary-border)]
+    flex w-full min-w-0 bg-background shadow-xs font-normal leading-[140%]
+    transition-[color,box-shadow] outline-none
+    disabled:bg-[var(--disabled)] disabled:placeholder:text-[var(--primary-foreground-disabled)]  disabled:text-[var(--primary-foreground-disabled)] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-none
     hover:border-[var(--primary)] 
-
     focus:border-[var(--primary)] 
-
     aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive
   `,
   {
     variants: {
       size: {
         xs: 'px-[0.5rem] h-[1.5rem] text-xs',
-        sm: 'px-[0.5rem] h-[2rem] text-sm',
-        md: 'px-[0.5rem] h-[2.25rem] text-base',
-        lg: 'px-[0.5rem] h-[2.5rem] text-lg',
+        sm: 'px-[0.5rem] h-[2rem] text-xs',
+        md: 'px-[0.5rem] h-[2.25rem] text-sm',
+        lg: 'px-[0.5rem] h-[2.5rem] text-sm',
       },
     },
     defaultVariants: {
@@ -36,6 +32,7 @@ type OtherProps = {
   disabled?: boolean
   className?: string
   icon?: React.ReactNode
+  prefix?: string
 }
 
 type InputProps = Omit<ComponentProps<'input'>, 'size'> &
@@ -48,9 +45,26 @@ const iconVariants = cva(
     variants: {
       size: {
         xs: '[&_svg]:h-[0.75rem] [&_svg]:w-[0.75rem]',
-        sm: '[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]',
-        md: '[&_svg]:h-[1rem] [&_svg]:w-[1rem]',
-        lg: '[&_svg]:h-[1.125rem] [&_svg]:w-[1.125rem]',
+        sm: '[&_svg]:h-[0.75rem] [&_svg]:w-[0.75rem]',
+        md: '[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]',
+        lg: '[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  },
+)
+
+const prefixVariants = cva(
+  'absolute left-[0.5rem] flex items-center pointer-events-none text-muted-foreground',
+  {
+    variants: {
+      size: {
+        xs: 'text-xs',
+        sm: 'text-xs',
+        md: 'text-sm',
+        lg: 'text-sm',
       },
     },
     defaultVariants: {
@@ -60,18 +74,33 @@ const iconVariants = cva(
 )
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, size, icon, ...props }, ref) => {
+  ({ className, type, size, icon, prefix, ...props }, ref) => {
+    const prefixRef = useRef<HTMLSpanElement>(null)
+    const [prefixWidth, setPrefixWidth] = useState(0)
+
+    useLayoutEffect(() => {
+      if (prefixRef.current) {
+        setPrefixWidth(prefixRef.current.offsetWidth + 8)
+      }
+    }, [prefix])
+
     return (
       <div className="relative flex items-center w-full">
         {!!icon && <span className={cn(iconVariants({ size }))}>{icon}</span>}
+        {!!prefix && (
+          <span ref={prefixRef} className={cn(prefixVariants({ size }))}>
+            {prefix}
+          </span>
+        )}
         <input
           type={type}
           className={cn(inputVariants({ size, className }), {
-            'pl-[1.75rem]': icon && size === 'xs',
-            'pl-[1.875rem]': icon && size === 'sm',
-            'pl-[2rem]': icon && size === 'md',
-            'pl-[2.25rem]': icon && size === 'lg',
+            'pl-[1.75rem]': icon && (size === 'xs' || size === 'sm'),
+            'pl-[1.875rem]': icon && (size === 'md' || size === 'lg'),
           })}
+          style={{
+            paddingLeft: prefix ? `${prefixWidth + 8}px` : '',
+          }}
           ref={ref}
           {...props}
         />

--- a/packages/ui/src/components/ui/radio-group/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group/radio-group.tsx
@@ -32,10 +32,10 @@ const radioGroupVariants = cva(
 const labelVariants = cva('text-white font-normal', {
   variants: {
     size: {
-      xs: 'text-[0.75rem] leading-[1.2] tracking-[0.005rem]',
-      sm: 'text-[0.8125rem] leading-[1.3] tracking-[0.006rem]',
-      md: 'text-[0.875rem] leading-[1.5] tracking-[0.007rem]',
-      lg: 'text-[1rem] leading-[1.6] tracking-[0.01rem]',
+      xs: 'text-xs leading-[1.2] tracking-[0.005rem]',
+      sm: 'text-sm leading-[1.3] tracking-[0.006rem]',
+      md: 'text-md leading-[1.5] tracking-[0.007rem]',
+      lg: 'text-lg leading-[1.6] tracking-[0.01rem]',
     },
   },
   defaultVariants: {
@@ -62,7 +62,7 @@ const circleIconVariants = cva(
   {
     variants: {
       size: {
-        xs: 'size-3 stroke-[0.5rem] rounded-full',
+        xs: 'size-3 stroke-[0.6rem] rounded-full',
         sm: 'size-3.5 stroke-[0.5rem] rounded-full',
         md: 'size-4 stroke-[0.5rem] rounded-full',
         lg: 'size-6 stroke-[0.5rem] rounded-full',

--- a/packages/ui/src/components/ui/select/select.test.tsx
+++ b/packages/ui/src/components/ui/select/select.test.tsx
@@ -56,9 +56,9 @@ describe('Select', () => {
 
     it.each([
       ['xs', 'px-[0.5rem] h-[1.5rem] text-xs'],
-      ['sm', 'px-[0.5rem] h-[2rem] text-sm'],
-      ['md', 'px-[0.5rem] h-[2.25rem] text-base'],
-      ['lg', 'px-[0.5rem] h-[2.5rem] text-lg'],
+      ['sm', 'px-[0.5rem] h-[2rem] text-xs'],
+      ['md', 'px-[0.5rem] h-[2.25rem] text-sm'],
+      ['lg', 'px-[0.5rem] h-[2.5rem] text-sm'],
     ])('should apply the correct styles for size %s', (size, expectedClass) => {
       setup({ size })
       const trigger = screen.getByRole('button')

--- a/packages/ui/src/components/ui/select/select.tsx
+++ b/packages/ui/src/components/ui/select/select.tsx
@@ -6,11 +6,14 @@ import { cn } from '@/lib/utils'
 
 const selectVariants = cva(
   `
-    text-white data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50  flex w-fit items-center justify-between gap-2 rounded-[0.25rem]  bg-neutral-900 px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px]  data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4
+    text-white font-normal leading-[140%] data-[placeholder]:text-muted-foreground 
+    [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50  flex w-fit items-center justify-between gap-2 
+    bg-background px-3 py-2 whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px]  *:data-[slot=select-value]:line-clamp-1 
+    *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4
 
     shadow-[0_1px_2px_rgba(0,0,0,0.05)]  border border-[var(--secondary-border)]
 
-    disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm disabled:bg-[var(--disabled)] disabled:text-[var(--primary-foreground-disabled)]
+    disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50  disabled:bg-[var(--disabled)] disabled:text-[var(--primary-foreground-disabled)]
 
     hover:border-[var(--primary)] 
 
@@ -20,9 +23,9 @@ const selectVariants = cva(
     variants: {
       size: {
         xs: 'px-[0.5rem] h-[1.5rem] text-xs',
-        sm: 'px-[0.5rem] h-[2rem] text-sm',
-        md: 'px-[0.5rem] h-[2.25rem] text-base',
-        lg: 'px-[0.5rem] h-[2.5rem] text-lg',
+        sm: 'px-[0.5rem] h-[2rem] text-xs',
+        md: 'px-[0.5rem] h-[2.25rem] text-sm',
+        lg: 'px-[0.5rem] h-[2.5rem] text-sm',
       },
     },
     defaultVariants: {
@@ -37,9 +40,9 @@ const popoverContentItemVariants = cva(
     variants: {
       size: {
         xs: 'px-2 py-1 text-xs',
-        sm: 'px-2 py-1.5 text-sm',
-        md: 'px-2 py-2 text-base',
-        lg: 'px-2 py-2.5 text-lg',
+        sm: 'px-2 py-1.5 text-xs',
+        md: 'px-2 py-2 text-sm',
+        lg: 'px-2 py-2.5 text-sm',
       },
     },
     defaultVariants: {
@@ -194,7 +197,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
             >
               {isCombobox && (
                 <>
-                  <div className="relative p-1">
+                  <div className="relative">
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--muted-foreground)]" />
                     <input
                       ref={inputRef}
@@ -227,10 +230,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
                   data-focused={focusedIndex === index}
                   tabIndex={-1}
                   onClick={() => handleSelect(option.value)}
-                  className={cn(
-                    popoverContentItemVariants({ size }),
-                    'rounded-none data-[focused=true]:bg-neutral-800',
-                  )}
+                  className={cn(popoverContentItemVariants({ size }))}
                 >
                   {option.label}
                   <Check


### PR DESCRIPTION

style(checkbox): refactor label text sizes to use Tailwind's text size classes for improved readability
style(input-otp): adjust input OTP styles for better visual consistency and alignment
style(input): add placeholder back to input story for completeness and clarity

test(input): update input component tests to reflect changes in size classes and add prefix functionality
feat(input): implement prefix prop for input component to enhance usability and styling options
style(input): adjust padding and text size classes for input variants to ensure consistency and improve appearance

fix(radio-group.tsx): update text size classes to use Tailwind's shorthand for consistency
fix(select.tsx): correct size classes in select variants to match expected styles
fix(select.test.tsx): adjust expected styles in tests to align with updated size classes
fix(select.tsx): remove unnecessary padding class from the search input wrapper for cleaner layout