### PR TITLE
feat(range-slider): add range slider component with customizable values and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ npx ui-startkit@latest add progress-bar
 npx ui-startkit@latest add radio-group
 ```
 
+### Range Slider
+
+```bash
+npx ui-startkit@latest add range-slider
+```
+
 ### Score Bar
 
 ```bash

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -138,6 +138,12 @@ npx ui-startkit@latest add progress-bar
 npx ui-startkit@latest add radio-group
 ```
 
+### Range Slider
+
+```bash
+npx ui-startkit@latest add range-slider
+```
+
 ### Score Bar
 
 ```bash

--- a/packages/ui/src/components/ui/range-slider/index.tsx
+++ b/packages/ui/src/components/ui/range-slider/index.tsx
@@ -1,0 +1,1 @@
+export { RangeSlider } from './range-slider'

--- a/packages/ui/src/components/ui/range-slider/range-slider.stories.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.stories.tsx
@@ -5,7 +5,6 @@ const meta: Meta<typeof RangeSlider> = {
   title: 'Components/Range Slider',
   component: RangeSlider,
   tags: ['autodocs'],
-  argTypes: {},
 }
 
 export default meta

--- a/packages/ui/src/components/ui/range-slider/range-slider.stories.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { RangeSlider } from '.'
+
+const meta: Meta<typeof RangeSlider> = {
+  title: 'Components/Range Slider',
+  component: RangeSlider,
+  tags: ['autodocs'],
+  argTypes: {},
+}
+
+export default meta
+
+type Story = StoryObj<typeof RangeSlider>
+
+export const Default: Story = {
+  args: {},
+}

--- a/packages/ui/src/components/ui/range-slider/range-slider.test.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { RangeSlider } from '.'
+
+describe('RangeSlider', () => {
+  it('should render with default values', () => {
+    render(<RangeSlider />)
+    const inputs = screen.getAllByRole('slider')
+    expect(inputs).toHaveLength(2)
+    expect((inputs[0] as HTMLInputElement).value).toBe('20')
+    expect((inputs[1] as HTMLInputElement).value).toBe('80')
+  })
+
+  it('should render with custom initial values', () => {
+    render(<RangeSlider initialMin={10} initialMax={90} />)
+    const inputs = screen.getAllByRole('slider')
+    expect((inputs[0] as HTMLInputElement).value).toBe('10')
+    expect((inputs[1] as HTMLInputElement).value).toBe('90')
+  })
+
+  it('should call onChange when min value changes', () => {
+    const onChange = vi.fn()
+    render(<RangeSlider onChange={onChange} />)
+    const inputs = screen.getAllByRole('slider')
+    fireEvent.change(inputs[0], { target: { value: '25' } })
+    expect(onChange).toHaveBeenCalledWith({ min: 25, max: 80 })
+  })
+
+  it('should not allow min value to exceed max - step', () => {
+    const onChange = vi.fn()
+    render(<RangeSlider step={5} initialMax={30} onChange={onChange} />)
+    const inputs = screen.getAllByRole('slider')
+    fireEvent.change(inputs[0], { target: { value: '50' } })
+    expect((inputs[0] as HTMLInputElement).value).toBe('25')
+    expect(onChange).toHaveBeenCalledWith({ min: 25, max: 30 })
+  })
+
+  it('should call onChange when max value changes', () => {
+    const onChange = vi.fn()
+    render(<RangeSlider onChange={onChange} />)
+    const inputs = screen.getAllByRole('slider')
+    fireEvent.change(inputs[1], { target: { value: '70' } })
+    expect(onChange).toHaveBeenCalledWith({ min: 20, max: 70 })
+  })
+
+  it('should not allow max value to go below min + step', () => {
+    const onChange = vi.fn()
+    render(<RangeSlider step={5} initialMin={30} onChange={onChange} />)
+    const inputs = screen.getAllByRole('slider')
+    fireEvent.change(inputs[1], { target: { value: '10' } })
+    expect((inputs[1] as HTMLInputElement).value).toBe('35')
+    expect(onChange).toHaveBeenCalledWith({ min: 30, max: 35 })
+  })
+
+  it('should display values when displayValues is true', () => {
+    render(<RangeSlider initialMin={15} initialMax={45} displayValues />)
+    expect(screen.getByText('15')).toBeInTheDocument()
+    expect(screen.getByText('45')).toBeInTheDocument()
+  })
+
+  it('should not display values when displayValues is false', () => {
+    render(<RangeSlider initialMin={15} initialMax={45} />)
+    expect(screen.queryByText('15')).toBeNull()
+    expect(screen.queryByText('45')).toBeNull()
+  })
+})

--- a/packages/ui/src/components/ui/range-slider/range-slider.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.tsx
@@ -89,7 +89,7 @@ export function RangeSlider({
       </div>
 
       {displayValues && (
-        <div className="flex justify-between w-full mt-1 text-sm text-white">
+        <div className="flex justify-between w-full mt-1 text-xs text-white">
           <span>{minVal}</span>
           <span>{maxVal}</span>
         </div>

--- a/packages/ui/src/components/ui/range-slider/range-slider.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.tsx
@@ -1,0 +1,99 @@
+'use client'
+import React, { useState } from 'react'
+
+type RangeSliderProps = {
+  min?: number
+  max?: number
+  step?: number
+  initialMin?: number
+  initialMax?: number
+  displayValues?: boolean
+  onChange?: (values: { min: number; max: number }) => void
+}
+
+export function RangeSlider({
+  min = 0,
+  max = 100,
+  step = 1,
+  initialMin = 20,
+  initialMax = 80,
+  displayValues,
+  onChange,
+}: RangeSliderProps) {
+  const [minVal, setMinVal] = useState(initialMin)
+  const [maxVal, setMaxVal] = useState(initialMax)
+
+  const handleMinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Math.min(Number(e.target.value), maxVal - step)
+    setMinVal(value)
+    onChange?.({ min: value, max: maxVal })
+  }
+
+  const handleMaxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Math.max(Number(e.target.value), minVal + step)
+    setMaxVal(value)
+    onChange?.({ min: minVal, max: value })
+  }
+
+  const thumbClassName = `
+    absolute w-full h-1 bg-transparent appearance-none pointer-events-none
+    [&::-webkit-slider-thumb]:pointer-events-auto 
+    [&::-webkit-slider-thumb]:appearance-none 
+    [&::-webkit-slider-thumb]:h-3.5 
+    [&::-webkit-slider-thumb]:w-3.5 
+    [&::-webkit-slider-thumb]:rounded-full 
+    [&::-webkit-slider-thumb]:bg-white 
+    [&::-webkit-slider-thumb]:border-1 
+    [&::-webkit-slider-thumb]:border-primary 
+    [&::-webkit-slider-thumb]:cursor-pointer 
+    [&::-moz-range-thumb]:pointer-events-auto 
+    [&::-moz-range-thumb]:h-3.5 
+    [&::-moz-range-thumb]:w-3.5 
+    [&::-moz-range-thumb]:rounded-full 
+    [&::-moz-range-thumb]:bg-white
+    [&::-moz-range-thumb]:border-1 
+    [&::-moz-range-thumb]:border-primary
+    [&::-moz-range-thumb]:cursor-pointer
+  `
+
+  return (
+    <div className="relative w-full flex flex-col items-center">
+      <div className="relative w-full h-[0.38rem] rounded-full bg-[var(--disabled)]">
+        <div
+          className="absolute h-[0.38rem] bg-primary rounded-full"
+          style={{
+            left: `${((minVal - min) / (max - min)) * 100}%`,
+            width: `${((maxVal - minVal) / (max - min)) * 100}%`,
+          }}
+        ></div>
+
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={minVal}
+          onChange={handleMinChange}
+          className={thumbClassName}
+        />
+
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={maxVal}
+          onChange={handleMaxChange}
+          className={thumbClassName}
+        />
+      </div>
+
+      {displayValues && (
+        <div className="flex justify-between w-full mt-1 text-sm text-white">
+          <span>{minVal}</span>
+          <span>{maxVal}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/registry.json
+++ b/registry.json
@@ -262,6 +262,16 @@
           "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/lib/utils.ts"
         }
       ]
+    },
+    "range-slider": {
+      "name": "Range Slider",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "components/ui/range-slider.tsx",
+          "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/score-bar/range-slider.tsx"
+        }
+      ]
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -269,7 +269,7 @@
       "files": [
         {
           "path": "components/ui/range-slider.tsx",
-          "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/score-bar/range-slider.tsx"
+          "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/range-slider/range-slider.tsx"
         }
       ]
     }


### PR DESCRIPTION
docs(README): update documentation to include range slider installation instructions
docs(README.pt-br): update Portuguese documentation to include range slider installation instructions
test(range-slider): add unit tests for range slider component functionality

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 21:36:35 UTC

<h3>Summary</h3>
This PR adds a new RangeSlider component to the ui-startkit library, providing dual-handle range slider functionality for form inputs. The implementation creates a component that allows users to select a range of values using two draggable thumbs with collision prevention to maintain proper min/max relationships.

The RangeSlider component is built using two overlapping HTML range inputs with custom CSS styling to create the appearance of a single slider with dual thumbs. This approach leverages native browser accessibility features while providing the visual dual-range functionality. The component includes customizable min/max bounds, step intervals, optional initial values, and callback support for value changes. It also features visual feedback with a highlighted track between the selected range.

The PR follows the established patterns in the ui-startkit codebase by including comprehensive test coverage, Storybook integration for documentation, proper TypeScript typing, and Tailwind CSS styling. The component is registered in the central registry.json file for CLI distribution and documented in both English and Portuguese README files. The implementation maintains consistency with other UI components in the library through proper directory structure, index file exports, and standardized testing approaches.

This addition expands the form input options available in the ui-startkit, providing developers with a modern, accessible range selection component that integrates seamlessly with the existing component ecosystem.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| registry.json | 1/5 | Critical path error in contentUrl pointing to wrong directory (score-bar instead of range-slider) |
| packages/ui/src/components/ui/range-slider/range-slider.test.tsx | 4/5 | Comprehensive test suite covering component functionality, boundaries, and callbacks |
| packages/ui/src/components/ui/range-slider/range-slider.stories.tsx | 4/5 | Basic Storybook configuration with minimal stories setup |
| packages/ui/src/components/ui/range-slider/range-slider.tsx | 3/5 | Dual-handle range slider implementation with potential division by zero and validation issues |
| README.md | 2/5 | Documentation update for range slider installation, affected by registry path error |
| packages/ui/src/components/ui/range-slider/index.tsx | 5/5 | Clean component export following established patterns |
| README.pt-br.md | 2/5 | Portuguese documentation update, affected by registry path error |

</details>

## Confidence score: 2/5

- This PR has a critical configuration error that will cause the CLI installation to fail completely
- Score lowered due to incorrect contentUrl in registry.json pointing to wrong directory path
- Pay close attention to registry.json and range-slider.tsx for path corrections and edge case handling

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as "ui-startkit CLI"
    participant Registry as "registry.json"
    participant GitHub as "GitHub Repository"
    participant FileSystem as "User's Project"

    User->>CLI: "npx ui-startkit@latest add range-slider"
    CLI->>Registry: "Read registry.json"
    Registry-->>CLI: "Return range-slider component config"
    CLI->>GitHub: "Fetch range-slider.tsx from contentUrl"
    GitHub-->>CLI: "Return component source code"
    CLI->>FileSystem: "Create components/ui/range-slider.tsx"
    CLI-->>User: "Range slider component installed"

    Note over User, FileSystem: User can now import and use RangeSlider component

    User->>FileSystem: "import { RangeSlider } from '@/components/ui/range-slider'"
    User->>FileSystem: "Render <RangeSlider onChange={handleChange} />"
    FileSystem->>User: "Range slider with dual thumbs displayed"
    
    User->>FileSystem: "Drag min/max sliders"
    FileSystem->>User: "onChange callback triggered with {min, max} values"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->