### PR TITLE
feat(color-picker): add Color Picker component with stories and tests to enhance UI toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ npx ui-startkit@latest add card
 npx ui-startkit@latest add checkbox
 ```
 
+### Color Picker
+
+```bash
+npx ui-startkit@latest add color-picker
+```
+
 ### Date Picker
 
 ```bash

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -102,10 +102,10 @@ npx ui-startkit@latest add card
 npx ui-startkit@latest add checkbox
 ```
 
-### Checkbox
+### Color Picker
 
 ```bash
-npx ui-startkit@latest add checkbox
+npx ui-startkit@latest add color-picker
 ```
 
 ### Date Picker

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -102,6 +102,12 @@ npx ui-startkit@latest add card
 npx ui-startkit@latest add checkbox
 ```
 
+### Checkbox
+
+```bash
+npx ui-startkit@latest add checkbox
+```
+
 ### Date Picker
 
 ```bash

--- a/packages/ui/src/components/ui/color-picker/color-picker.stories.tsx
+++ b/packages/ui/src/components/ui/color-picker/color-picker.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ColorPicker } from '.'
+
+const meta: Meta<typeof ColorPicker> = {
+  title: 'Components/Color Picker',
+  component: ColorPicker,
+  tags: ['autodocs'],
+  argTypes: {
+    selectedIndex: {
+      description:
+        'Índice usado como opção selecionada por padrão, começando em 0, de acordo com a quantidade de itens em options.',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ColorPicker>
+
+export const Default: Story = {
+  args: {
+    options: [
+      { from: '#0055FF', to: '#00D7FF' },
+      { from: '#654229', to: '#B37448' },
+      { from: '#999999', to: '#CCCCCC' },
+      { from: '#178B00', to: '#B4D40C' },
+      { from: '#8F00FF', to: '#FF33DD' },
+      { from: '#FF2101', to: '#FF6900' },
+      { from: '#FFC802', to: '#FFFA02' },
+    ],
+    selectedIndex: 2,
+  },
+
+  render(props) {
+    return (
+      <div className="flex w-[12rem]">
+        <ColorPicker {...props} />
+      </div>
+    )
+  },
+}

--- a/packages/ui/src/components/ui/color-picker/color-picker.test.tsx
+++ b/packages/ui/src/components/ui/color-picker/color-picker.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ColorPicker } from '.'
+
+const options = [
+  { from: '#ff0000', to: '#00ff00' },
+  { from: '#0000ff', to: '#ffff00' },
+]
+
+describe('ColorPicker', () => {
+  it('should render all color options', () => {
+    render(<ColorPicker options={options} />)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(options.length)
+  })
+
+  it('should select color on click and call onSelect', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(<ColorPicker options={options} onSelect={onSelect} />)
+
+    const buttons = screen.getAllByRole('button')
+    await user.click(buttons[1])
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith({ from: '#0000ff', to: '#ffff00', index: 1 })
+  })
+
+  it('should apply selected styles when clicked', async () => {
+    const user = userEvent.setup()
+    render(<ColorPicker options={options} />)
+
+    const buttons = screen.getAllByRole('button')
+    await user.click(buttons[0])
+
+    expect(buttons[0]).toHaveClass('border-white')
+    expect(buttons[1]).not.toHaveClass('border-white')
+  })
+
+  it('should initialize with selectedIndex', () => {
+    render(<ColorPicker options={options} selectedIndex={1} />)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons[1]).toHaveClass('border-white')
+    expect(buttons[0]).not.toHaveClass('border-white')
+  })
+
+  it('should update selection when selectedIndex changes', () => {
+    const { rerender } = render(<ColorPicker options={options} selectedIndex={0} />)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons[0]).toHaveClass('border-white')
+
+    rerender(<ColorPicker options={options} selectedIndex={1} />)
+    expect(buttons[1]).toHaveClass('border-white')
+    expect(buttons[0]).not.toHaveClass('border-white')
+  })
+
+  it('should handle null selectedIndex without errors', () => {
+    render(<ColorPicker options={options} />)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons[0]).not.toHaveClass('border-white')
+    expect(buttons[1]).not.toHaveClass('border-white')
+  })
+})

--- a/packages/ui/src/components/ui/color-picker/color-picker.tsx
+++ b/packages/ui/src/components/ui/color-picker/color-picker.tsx
@@ -1,0 +1,70 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { cn } from '@/lib/utils'
+
+interface ColorOption {
+  from: string
+  to: string
+}
+
+interface ColorPickerProps {
+  options: ColorOption[]
+  onSelect?: (coloer: { from: string; to: string; index: number }) => void
+  selectedIndex?: number
+  className?: string
+}
+
+export function ColorPicker({ options, onSelect, selectedIndex, className }: ColorPickerProps) {
+  const [selectedColor, setSelectedColor] = useState<number | null>(null)
+
+  const handleColorClick = (index: number) => {
+    setSelectedColor(index)
+    const selected = options[index]
+    onSelect?.({
+      from: selected.from,
+      to: selected.to,
+      index,
+    })
+  }
+
+  useEffect(() => {
+    if (selectedIndex != null && options[selectedIndex]) {
+      setSelectedColor(selectedIndex)
+    }
+  }, [selectedIndex, options, onSelect])
+
+  return (
+    <div className={cn('inline-flex flex-col', className)}>
+      <div className="flex gap-2 flex-wrap">
+        {options.map((option, index) => (
+          <button
+            key={index}
+            onClick={() => handleColorClick(index)}
+            className={cn(
+              'relative cursor-pointer focus:outline-none rounded-xs p-[2px] border-[1.5px] border-transparent',
+              selectedColor === index &&
+                ' bg-transparent rounded-[0.25rem] border-[1.5px] border-white',
+            )}
+          >
+            <div className="size-[calc(1.5rem-3px)] relative rounded-xs overflow-hidden">
+              <div
+                className="absolute inset-0"
+                style={{
+                  clipPath: 'polygon(0 0, 100% 0, 0 100%)',
+                  backgroundColor: option.from,
+                }}
+              />
+              <div
+                className="absolute inset-0"
+                style={{
+                  clipPath: 'polygon(100% 0, 100% 100%, 0 100%)',
+                  backgroundColor: option.to,
+                }}
+              />
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/components/ui/color-picker/color-picker.tsx
+++ b/packages/ui/src/components/ui/color-picker/color-picker.tsx
@@ -9,7 +9,7 @@ interface ColorOption {
 
 interface ColorPickerProps {
   options: ColorOption[]
-  onSelect?: (coloer: { from: string; to: string; index: number }) => void
+  onSelect?: (color: { from: string; to: string; index: number }) => void
   selectedIndex?: number
   className?: string
 }
@@ -31,7 +31,7 @@ export function ColorPicker({ options, onSelect, selectedIndex, className }: Col
     if (selectedIndex != null && options[selectedIndex]) {
       setSelectedColor(selectedIndex)
     }
-  }, [selectedIndex, options, onSelect])
+  }, [selectedIndex, options])
 
   return (
     <div className={cn('inline-flex flex-col', className)}>

--- a/packages/ui/src/components/ui/color-picker/index.tsx
+++ b/packages/ui/src/components/ui/color-picker/index.tsx
@@ -1,0 +1,1 @@
+export { ColorPicker } from './color-picker'

--- a/registry.json
+++ b/registry.json
@@ -275,7 +275,7 @@
     },
     "color-picker": {
       "name": "Color Picker",
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "components/ui/color-picker.tsx",

--- a/registry.json
+++ b/registry.json
@@ -272,6 +272,16 @@
           "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/range-slider/range-slider.tsx"
         }
       ]
+    },
+    "color-picker": {
+      "name": "Color Picker",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "components/ui/color-picker.tsx",
+          "contentUrl": "https://raw.githubusercontent.com/roxygens/ui-startkit/refs/heads/main/packages/ui/src/components/ui/color-picker/color-picker.tsx"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
docs(README): update documentation to include Color Picker usage instructions
docs(README.pt-br): update Portuguese documentation to include Color Picker instructions

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-02 21:57:45 UTC

<h3>Summary</h3>
This PR introduces a new Color Picker component to the UI toolkit, enabling users to select from predefined gradient color combinations. The component displays color options as diagonal split gradients using CSS clip paths and supports both controlled and uncontrolled usage patterns through a `selectedIndex` prop and `onSelect` callback.

The implementation follows the established architectural patterns of the codebase, including:
- Component organization with separate files for implementation, exports, tests, and Storybook stories
- TypeScript interfaces for type safety
- Integration with the existing utility functions (`cn` for className composition)
- Comprehensive test coverage using React Testing Library and Vitest
- Storybook documentation for interactive examples

The component integrates into the broader UI toolkit ecosystem through updates to `registry.json`, which enables CLI installation via `npx ui-startkit@latest add color-picker`. Documentation has been updated in both English and Portuguese README files to inform users of the new component's availability.

The Color Picker component enhances the toolkit by providing a specialized input for color selection scenarios, displaying gradient color pairs in a visually appealing diagonal split format with clear selection feedback through border styling.
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 5/5 | Added proper documentation for Color Picker component installation |
| packages/ui/src/components/ui/color-picker/color-picker.tsx | 3/5 | New Color Picker component with typo in interface and potential useEffect issues |
| registry.json | 2/5 | Added Color Picker to component registry but references component with critical typo |
| README.pt-br.md | 1/5 | Critical error - duplicated Checkbox section instead of adding Color Picker |
| packages/ui/src/components/ui/color-picker/index.tsx | 4/5 | Clean export file following established patterns |
| packages/ui/src/components/ui/color-picker/color-picker.test.tsx | 4/5 | Comprehensive test coverage for component functionality |
| packages/ui/src/components/ui/color-picker/color-picker.stories.tsx | 4/5 | Storybook stories with minor language inconsistency |

</details>
<h3>Confidence score: 2/5</h3>

- This PR requires careful review due to critical bugs that will cause runtime errors and documentation issues
- Score lowered due to typo in component interface (`coloer` instead of `color`) and completely incorrect Portuguese documentation
- Pay close attention to `packages/ui/src/components/ui/color-picker/color-picker.tsx` and `README.pt-br.md` which need immediate fixes before merge

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as "ui-startkit CLI"
    participant Registry as "registry.json"
    participant FileSystem as "File System"
    participant ColorPicker as "Color Picker Component"

    User->>CLI: "npx ui-startkit@latest add color-picker"
    CLI->>Registry: "Read component definition"
    Registry-->>CLI: "Return color-picker config"
    CLI->>FileSystem: "Create components/ui/color-picker.tsx"
    CLI->>FileSystem: "Copy component from GitHub URL"
    FileSystem-->>User: "Component installed successfully"
    
    User->>ColorPicker: "Import and use component"
    User->>ColorPicker: "Pass options array with color gradients"
    User->>ColorPicker: "Click color option"
    ColorPicker->>ColorPicker: "Update selected state"
    ColorPicker->>User: "Call onSelect callback with color data"
    ColorPicker->>ColorPicker: "Apply visual selection styling"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->