### PR TITLE
fix(modal): update text size from text-md to text-base for consistenc…

### DIFF
--- a/packages/ui/src/components/ui/modal/modal.test.tsx
+++ b/packages/ui/src/components/ui/modal/modal.test.tsx
@@ -26,7 +26,7 @@ describe('Modal', () => {
     )
     await user.click(screen.getByTestId('trigger'))
     expect(await screen.findByTestId('modal-content')).toBeInTheDocument()
-    expect(screen.getByText(title)).toHaveClass('text-md sm:text-xl')
+    expect(screen.getByText(title)).toHaveClass('text-base sm:text-xl')
   })
 
   it('should call onOpenChange when modal is opened and closed', async () => {

--- a/packages/ui/src/components/ui/modal/modal.tsx
+++ b/packages/ui/src/components/ui/modal/modal.tsx
@@ -90,7 +90,7 @@ export function Modal({ open, onOpenChange, title, content, className, children 
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className={className}>
         <div className="absolute sm:left-[5rem] py-[1.5rem] pl-[1rem] border-b-1 border-[var(--table-border)] w-screen sm:w-[calc(100%-10rem)]">
-          <div className="w-[calc(100%-4rem)] sm:w-[calc(100%-8rem)] text-white text-md sm:text-xl leading-[120%] font-semibold">
+          <div className="w-[calc(100%-4rem)] sm:w-[calc(100%-8rem)] text-white text-base sm:text-xl leading-[120%] font-semibold">
             {title}
           </div>
         </div>


### PR DESCRIPTION
…y in modal component styling

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-03 12:49:24 UTC

<h3>Summary</h3>
This PR makes a small but important styling consistency fix to the Modal component in the UI startkit. The change updates the text size class from `text-md` to `text-base` in the modal title element.

The core issue being addressed is that `text-md` is not a standard Tailwind CSS class - the correct class for base/medium text size (16px) is `text-base`. This change aligns the Modal component with standard Tailwind CSS naming conventions and ensures consistency across the UI component library.

The Modal component is part of the reusable UI components collection in this startkit, which provides standardized, accessible components for React applications. By using proper Tailwind classes, the component maintains better compatibility with standard Tailwind CSS configurations and follows established conventions that other developers would expect.

The change preserves the responsive design pattern where text displays at base size on mobile devices and scales up to xl size on small screens and larger (`text-base sm:text-xl`). This maintains the intended visual hierarchy while using the correct CSS class naming.

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/ui/src/components/ui/modal/modal.tsx | 5/5 | Updated text size class from non-standard `text-md` to standard `text-base` for Tailwind CSS compliance |
| packages/ui/src/components/ui/modal/modal.test.tsx | 5/5 | Updated test assertion to match the corrected CSS class in the modal component |

</details>
<h3>Confidence score: 5/5</h3>

- This PR is extremely safe to merge with no risk of breaking changes
- Score reflects a simple, well-understood styling fix that improves code standards and consistency
- No files require special attention - both changes are straightforward and properly coordinated

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->