### PR TITLE
feat(input): add 'xl' size variant to Input component for enhanced usability

### DIFF
--- a/packages/ui/src/components/ui/input/input.stories.tsx
+++ b/packages/ui/src/components/ui/input/input.stories.tsx
@@ -1,13 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Input } from '.'
 
+import { Search } from 'lucide-react'
+
 const meta: Meta<typeof Input> = {
   title: 'Components/Input',
   component: Input,
   tags: ['autodocs'],
   argTypes: {
     size: {
-      options: ['xs', 'sm', 'md', 'lg'],
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
       control: { type: 'select' },
     },
     type: {

--- a/packages/ui/src/components/ui/input/input.test.tsx
+++ b/packages/ui/src/components/ui/input/input.test.tsx
@@ -76,6 +76,13 @@ describe('Input', () => {
       expect(inputElement).toHaveClass('px-[0.5rem] h-[2.5rem] text-sm')
     })
 
+    it('should apply specified size variant (xl) classes', () => {
+      render(<Input size="xl" />)
+      const inputElement = screen.getByRole('textbox')
+
+      expect(inputElement).toHaveClass('px-[0.5rem] h-[3rem] text-base')
+    })
+
     it('should merge additional classNames with variant classes', () => {
       render(<Input size="lg" className="my-custom-class" />)
       const inputElement = screen.getByRole('textbox')
@@ -121,6 +128,12 @@ describe('Input', () => {
     expect(input).toHaveClass('pl-[1.875rem]')
   })
 
+  it('should render with xl size and icon', () => {
+    render(<Input data-testid="input" size="xl" icon={<Home data-testid="icon" />} />)
+    const input = screen.getByTestId('input')
+    expect(input).toHaveClass('pl-[2rem]')
+  })
+
   it('should render with xs size and icon applying iconVariants', () => {
     render(<Input data-testid="input" size="xs" icon={<Home data-testid="icon" />} />)
     const icon = screen.getByTestId('icon')
@@ -143,6 +156,12 @@ describe('Input', () => {
     render(<Input data-testid="input" size="lg" icon={<Home data-testid="icon" />} />)
     const icon = screen.getByTestId('icon')
     expect(icon.parentElement).toHaveClass('[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]')
+  })
+
+  it('should render with xl size and icon applying iconVariants', () => {
+    render(<Input data-testid="input" size="xl" icon={<Home data-testid="icon" />} />)
+    const icon = screen.getByTestId('icon')
+    expect(icon.parentElement).toHaveClass('[&_svg]:h-[1rem] [&_svg]:w-[1rem]')
   })
 
   it('should render prefix with xs size and correct variant classes', () => {
@@ -170,6 +189,13 @@ describe('Input', () => {
     render(<Input data-testid="input" size="lg" prefix="R$" />)
     const prefix = screen.getByText('R$')
     expect(prefix).toHaveClass('text-sm')
+    expect(prefix).toHaveClass('absolute')
+  })
+
+  it('should render prefix with xl size and correct variant classes', () => {
+    render(<Input data-testid="input" size="xl" prefix="R$" />)
+    const prefix = screen.getByText('R$')
+    expect(prefix).toHaveClass('text-base')
     expect(prefix).toHaveClass('absolute')
   })
 

--- a/packages/ui/src/components/ui/input/input.tsx
+++ b/packages/ui/src/components/ui/input/input.tsx
@@ -20,6 +20,7 @@ const inputVariants = cva(
         sm: 'px-[0.5rem] h-[2rem] text-xs',
         md: 'px-[0.5rem] h-[2.25rem] text-sm',
         lg: 'px-[0.5rem] h-[2.5rem] text-sm',
+        xl: 'px-[0.5rem] h-[3rem] text-base',
       },
     },
     defaultVariants: {
@@ -48,6 +49,7 @@ const iconVariants = cva(
         sm: '[&_svg]:h-[0.75rem] [&_svg]:w-[0.75rem]',
         md: '[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]',
         lg: '[&_svg]:h-[0.875rem] [&_svg]:w-[0.875rem]',
+        xl: '[&_svg]:h-[1rem] [&_svg]:w-[1rem]',
       },
     },
     defaultVariants: {
@@ -65,6 +67,7 @@ const prefixVariants = cva(
         sm: 'text-xs',
         md: 'text-sm',
         lg: 'text-sm',
+        xl: 'text-base',
       },
     },
     defaultVariants: {
@@ -97,6 +100,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           className={cn(inputVariants({ size, className }), {
             'pl-[1.75rem]': icon && (size === 'xs' || size === 'sm'),
             'pl-[1.875rem]': icon && (size === 'md' || size === 'lg'),
+            'pl-[2rem]': icon && size === 'xl',
           })}
           style={{
             paddingLeft: prefix ? `${prefixWidth + 8}px` : '',


### PR DESCRIPTION
test(input): add tests for 'xl' size variant to ensure correct rendering and styling
docs(input.stories): update storybook options to include 'xl' size for better component showcase