### PR TITLE
feat(input-otp): add default size and className props to InputOtp story for better customization

### DIFF
--- a/packages/ui/src/components/ui/input-otp/input-otp.stories.tsx
+++ b/packages/ui/src/components/ui/input-otp/input-otp.stories.tsx
@@ -23,6 +23,5 @@ type Story = StoryObj<typeof InputOtp>
 export const Default: Story = {
   args: {
     size: 'md',
-    className: '',
   },
 }

--- a/packages/ui/src/components/ui/input-otp/input-otp.tsx
+++ b/packages/ui/src/components/ui/input-otp/input-otp.tsx
@@ -32,6 +32,7 @@ type OtherProps = {
   disabled?: boolean
   type: 'text' | 'number'
   onChange?: (value: string | number) => void
+  className?: string
 }
 
 type InputOtpProps = Omit<React.ComponentProps<'input'>, 'size' | 'onChange' | 'type'> &

--- a/packages/ui/src/components/ui/range-slider/range-slider.test.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.test.tsx
@@ -64,17 +64,37 @@ describe('RangeSlider', () => {
     expect(screen.queryByText('45')).toBeNull()
   })
 
-  it('should update minVal and maxVal when values prop changes', () => {
-    const { rerender } = render(<RangeSlider />)
+  it('should clamp initialMin to min prop when initialMin is below min', () => {
+    render(<RangeSlider min={10} max={100} initialMin={0} displayValues />)
+    expect(screen.getByText('10')).toBeInTheDocument()
+  })
 
-    expect(screen.getByDisplayValue('20')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('80')).toBeInTheDocument()
+  it('should clamp initialMax to max prop when initialMax is above max', () => {
+    render(<RangeSlider min={0} max={50} initialMax={100} displayValues />)
+    expect(screen.getByText('50')).toBeInTheDocument()
+  })
 
-    const newValues = { min: 10, max: 90 }
+  it('should set initialMax equal to initialMin when initialMax is less than initialMin', () => {
+    render(<RangeSlider min={0} max={100} initialMin={60} initialMax={40} displayValues />)
+    const values = screen.getAllByText('60')
+    expect(values).toHaveLength(2)
+  })
 
-    rerender(<RangeSlider values={newValues} displayValues />)
-
+  it('should clamp values.min and values.max within props range', () => {
+    render(<RangeSlider min={10} max={90} values={{ min: 0, max: 100 }} displayValues />)
     expect(screen.getByText('10')).toBeInTheDocument()
     expect(screen.getByText('90')).toBeInTheDocument()
+  })
+
+  it('should set max equal to min when values.max is less than values.min', () => {
+    render(<RangeSlider min={0} max={100} values={{ min: 70, max: 50 }} displayValues />)
+    const values = screen.getAllByText('70')
+    expect(values).toHaveLength(2)
+  })
+
+  it('should keep values when inside the allowed range', () => {
+    render(<RangeSlider min={0} max={100} values={{ min: 30, max: 80 }} displayValues />)
+    expect(screen.getByText('30')).toBeInTheDocument()
+    expect(screen.getByText('80')).toBeInTheDocument()
   })
 })

--- a/packages/ui/src/components/ui/range-slider/range-slider.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.tsx
@@ -27,8 +27,16 @@ export function RangeSlider({
   onChange,
   values,
 }: RangeSliderProps) {
-  const [minVal, setMinVal] = useState(initialMin)
-  const [maxVal, setMaxVal] = useState(initialMax)
+  const clamp = (value: number, minValue: number, maxValue: number) =>
+    Math.max(minValue, Math.min(value, maxValue))
+
+  const clampedInitialMin = clamp(initialMin, min, max)
+  const clampedInitialMax = clamp(initialMax, min, max)
+  const validInitialMax =
+    clampedInitialMax < clampedInitialMin ? clampedInitialMin : clampedInitialMax
+
+  const [minVal, setMinVal] = useState(clampedInitialMin)
+  const [maxVal, setMaxVal] = useState(validInitialMax)
 
   const handleMinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Math.min(Number(e.target.value), maxVal - step)
@@ -44,10 +52,14 @@ export function RangeSlider({
 
   useEffect(() => {
     if (values) {
-      setMinVal(values.min)
-      setMaxVal(values.max)
+      const clampedMin = Math.max(min, Math.min(values.min, max))
+      const clampedMax = Math.max(min, Math.min(values.max, max))
+      const finalMax = clampedMax < clampedMin ? clampedMin : clampedMax
+
+      setMinVal(clampedMin)
+      setMaxVal(finalMax)
     }
-  }, [values])
+  }, [values, min, max])
 
   const thumbClassName = `
     absolute w-full h-1 bg-transparent appearance-none pointer-events-none


### PR DESCRIPTION
fix(input-otp): update className handling in InputOtp component to allow custom styles
feat(range-slider): add values prop to RangeSlider for dynamic min and max value updates
test(range-slider): add test case to verify minVal and maxVal update on values prop change

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-06 16:50:42 UTC

<h3>Summary</h3>
This PR implements two distinct improvements to the UI component library. The first addresses a bug in the InputOtp component's className handling, while the second adds controlled component functionality to the RangeSlider component.

**InputOtp Component Fix**: The change corrects how custom CSS classes are applied to the InputOtp component. Previously, the `className` prop was incorrectly passed to the `inputOtpVariants` function (which only accepts a `size` parameter), causing potential runtime issues. The fix moves className handling to the container div where it belongs, using the `cn` utility to properly merge custom styles with default styling. This follows standard UI component library patterns where className applies to the outermost container.

**RangeSlider Enhancement**: The component now supports controlled behavior through a new optional `values` prop of type `Values` (containing min and max numbers). When provided, a `useEffect` hook updates the internal `minVal` and `maxVal` state, allowing parent components to programmatically control the slider values. This enables scenarios like form binding, preset value buttons, or synchronization with external state while maintaining backward compatibility with the existing uncontrolled behavior.

**Integration with Codebase**: These changes enhance the component library's flexibility and correctness. The InputOtp fix resolves a styling API inconsistency, while the RangeSlider enhancement adds standard React controlled component patterns that developers expect from modern UI libraries. Both changes maintain backward compatibility and follow the established component architecture patterns used throughout the `roxygens/ui-startkit` project.
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/ui/src/components/ui/input-otp/input-otp.tsx | 5/5 | Fixed className handling by moving it to container div and removing from variants function |
| packages/ui/src/components/ui/input-otp/input-otp.stories.tsx | 4/5 | Added explicit default values for size and className props in Storybook configuration |
| packages/ui/src/components/ui/range-slider/range-slider.tsx | 3/5 | Added values prop for controlled component behavior but lacks input validation |
| packages/ui/src/components/ui/range-slider/range-slider.test.tsx | 4/5 | Added test case to verify controlled behavior when values prop changes |

</details>
<h3>Confidence score: 3/5</h3>

- This PR contains mostly safe changes but has one significant issue that could cause problems in production
- Score lowered due to missing input validation in the RangeSlider component's values prop implementation
- Pay close attention to packages/ui/src/components/ui/range-slider/range-slider.tsx for potential boundary validation issues

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant InputOtp
    participant RangeSlider
    participant DOM
    
    User->>InputOtp: "Types in OTP field"
    InputOtp->>InputOtp: "handleChange(index, value)"
    InputOtp->>InputOtp: "setValues(newValues)"
    InputOtp->>InputOtp: "onChange callback"
    alt "Value entered and not last field"
        InputOtp->>DOM: "Focus next input"
    end
    alt "Value deleted and not first field"
        InputOtp->>DOM: "Focus previous input"
    end
    
    User->>InputOtp: "Pastes data"
    InputOtp->>InputOtp: "handlePaste(index, event)"
    InputOtp->>InputOtp: "Process clipboard data"
    InputOtp->>InputOtp: "setValues(newValues)"
    InputOtp->>InputOtp: "onChange callback"
    InputOtp->>DOM: "Focus last filled input"
    
    User->>RangeSlider: "Moves min slider"
    RangeSlider->>RangeSlider: "handleMinChange(event)"
    RangeSlider->>RangeSlider: "setMinVal(value)"
    RangeSlider->>RangeSlider: "onChange callback"
    
    User->>RangeSlider: "Moves max slider"
    RangeSlider->>RangeSlider: "handleMaxChange(event)"
    RangeSlider->>RangeSlider: "setMaxVal(value)"
    RangeSlider->>RangeSlider: "onChange callback"
    
    User->>RangeSlider: "Updates values prop externally"
    RangeSlider->>RangeSlider: "useEffect triggers"
    RangeSlider->>RangeSlider: "setMinVal(values.min)"
    RangeSlider->>RangeSlider: "setMaxVal(values.max)"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->