### PR TITLE
feat(input): add mask options for currency, cpf, cnpj, and phone in input component stories

### DIFF
--- a/packages/ui/src/components/ui/input/input.stories.tsx
+++ b/packages/ui/src/components/ui/input/input.stories.tsx
@@ -10,8 +10,12 @@ const meta: Meta<typeof Input> = {
       options: ['xs', 'sm', 'md', 'lg', 'xl'],
       control: { type: 'select' },
     },
+    mask: {
+      options: ['currency', 'cpf', 'cnpj', 'phone', 'none'],
+      control: { type: 'select' },
+    },
     type: {
-      options: ['text', 'email', 'password', 'number', 'tel', 'url'],
+      options: ['text', 'email', 'password', 'number', 'tel', 'url', 'currency'],
       control: { type: 'select' },
     },
     'aria-invalid': {


### PR DESCRIPTION
test(input): enhance tests to cover masking functionality for currency, cpf, cnpj, and phone inputs

feat(input): add input masking feature for currency, phone, CPF, and CNPJ formats to enhance user experience and data consistency

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-06 19:11:10 UTC

<h3>Summary</h3>
This PR adds input masking functionality to the Input component, enabling automatic formatting for common input types including currency, phone numbers, CPF (Brazilian individual taxpayer ID), and CNPJ (Brazilian company ID). The implementation introduces a new `mask` prop that accepts predefined mask types ('currency', 'phone', 'cpf', 'cnpj') and automatically formats user input as they type.

The core changes modify the Input component to use internal state management for handling the difference between raw input values and their formatted display representations. When a mask is applied, the component maintains both the user's input and the formatted output, ensuring parent components receive properly formatted values through the `onChange` callback. For currency inputs, the component also adds `inputMode="numeric"` and `pattern="[0-9]*"` attributes to optimize mobile keyboard display.

The masking logic includes specific formatting functions for each type: currency formatting with Brazilian Real (R$) prefix and decimal handling, phone number formatting with Brazilian patterns supporting both landline and mobile formats, and CPF/CNPJ formatting with appropriate separator characters (dots, slashes, hyphens). The implementation maintains backward compatibility by making the mask prop optional and preserving existing component behavior when no mask is specified.

Storybook integration exposes these mask options through interactive controls, allowing developers and designers to test different masking behaviors. The test suite provides comprehensive coverage for both controlled and uncontrolled input scenarios, edge cases, and integration with existing component features.
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/ui/src/components/ui/input/input.tsx | 3/5 | Adds core masking functionality with internal state management and formatting logic for currency, phone, CPF, and CNPJ formats |
| packages/ui/src/components/ui/input/input.test.tsx | 3/5 | Introduces comprehensive test coverage for masking functionality including controlled/uncontrolled scenarios and edge cases |
| packages/ui/src/components/ui/input/input.stories.tsx | 5/5 | Adds Storybook controls to expose mask options and currency type for interactive testing |

</details>
<h3>Confidence score: 3/5</h3>

- This PR introduces significant functionality changes that require careful review due to complex state management and potential edge cases in mask formatting logic
- Score reflects concerns about incomplete return paths in phone masking, currency formatting edge cases, and the complexity of managing both controlled and uncontrolled input states
- Pay close attention to `packages/ui/src/components/ui/input/input.tsx` for potential runtime issues in mask formatting functions and state synchronization

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Input
    participant MaskUtility
    participant ChangeHandler
    
    User->>Input: "Types '12345678900' in CPF field"
    Input->>MaskUtility: "applyMask('12345678900')"
    MaskUtility->>MaskUtility: "Extract digits: '12345678900'"
    MaskUtility->>MaskUtility: "Apply CPF regex patterns"
    MaskUtility-->>Input: "Return '123.456.789-00'"
    Input->>ChangeHandler: "handleChange with masked value"
    ChangeHandler->>Input: "setInternalValue('123.456.789-00')"
    ChangeHandler->>Input: "props.onChange with masked event"
    Input-->>User: "Display '123.456.789-00'"
    
    User->>Input: "Types '12345' in currency field"
    Input->>MaskUtility: "applyMask('12345')"
    MaskUtility->>MaskUtility: "Remove non-digits: '12345'"
    MaskUtility->>MaskUtility: "Pad and format as currency"
    MaskUtility-->>Input: "Return '123,45'"
    Input->>ChangeHandler: "handleChange with masked value"
    ChangeHandler->>Input: "setInternalValue('123,45')"
    ChangeHandler->>Input: "props.onChange with masked event"
    Input-->>User: "Display '123,45'"
    
    User->>Input: "Types '11987654321' in phone field"
    Input->>MaskUtility: "applyMask('11987654321')"
    MaskUtility->>MaskUtility: "Extract digits and format phone"
    MaskUtility-->>Input: "Return '(11) 98765-4321'"
    Input->>ChangeHandler: "handleChange with masked value"
    ChangeHandler->>Input: "setInternalValue('(11) 98765-4321')"
    ChangeHandler->>Input: "props.onChange with masked event"
    Input-->>User: "Display '(11) 98765-4321'"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->