### PR TITLE
feat(range-slider): add onFinalChange prop to handle final value changes after interaction ends

### DIFF
--- a/packages/ui/src/components/ui/range-slider/range-slider.test.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.test.tsx
@@ -80,6 +80,18 @@ describe('RangeSlider', () => {
     expect(values).toHaveLength(2)
   })
 
+  it('should update state from controlled values prop', () => {
+    const { rerender } = render(<RangeSlider values={{ min: 10, max: 90 }} />)
+    let inputs = screen.getAllByRole('slider')
+    expect((inputs[0] as HTMLInputElement).value).toBe('10')
+    expect((inputs[1] as HTMLInputElement).value).toBe('90')
+
+    rerender(<RangeSlider values={{ min: 25, max: 75 }} />)
+    inputs = screen.getAllByRole('slider')
+    expect((inputs[0] as HTMLInputElement).value).toBe('25')
+    expect((inputs[1] as HTMLInputElement).value).toBe('75')
+  })
+
   it('should clamp values.min and values.max within props range', () => {
     render(<RangeSlider min={10} max={90} values={{ min: 0, max: 100 }} displayValues />)
     expect(screen.getByText('10')).toBeInTheDocument()
@@ -96,5 +108,42 @@ describe('RangeSlider', () => {
     render(<RangeSlider min={0} max={100} values={{ min: 30, max: 80 }} displayValues />)
     expect(screen.getByText('30')).toBeInTheDocument()
     expect(screen.getByText('80')).toBeInTheDocument()
+  })
+
+  it('should call onFinalChange with correct values on mouse up for min slider', () => {
+    const onFinalChange = vi.fn()
+    render(<RangeSlider onFinalChange={onFinalChange} />)
+    const inputs = screen.getAllByRole('slider')
+    fireEvent.change(inputs[0], { target: { value: '30' } })
+    fireEvent.mouseUp(inputs[0])
+    expect(onFinalChange).toHaveBeenCalledTimes(1)
+    expect(onFinalChange).toHaveBeenCalledWith({ min: 30, max: 80 })
+  })
+
+  it('should call onFinalChange with correct values on mouse up for max slider', () => {
+    const onFinalChange = vi.fn()
+    render(<RangeSlider onFinalChange={onFinalChange} />)
+    const inputs = screen.getAllByRole('slider')
+    fireEvent.change(inputs[1], { target: { value: '70' } })
+    fireEvent.mouseUp(inputs[1])
+    expect(onFinalChange).toHaveBeenCalledTimes(1)
+    expect(onFinalChange).toHaveBeenCalledWith({ min: 20, max: 70 })
+  })
+
+  it('should call onFinalChange with correct values on touch end for min slider', () => {
+    const onFinalChange = vi.fn()
+    render(<RangeSlider onFinalChange={onFinalChange} />)
+    const inputs = screen.getAllByRole('slider')
+    fireEvent.change(inputs[0], { target: { value: '45' } })
+    fireEvent.touchEnd(inputs[0])
+    expect(onFinalChange).toHaveBeenCalledTimes(1)
+    expect(onFinalChange).toHaveBeenCalledWith({ min: 45, max: 80 })
+  })
+
+  it('should not crash if onFinalChange is not provided', () => {
+    render(<RangeSlider />)
+    const inputs = screen.getAllByRole('slider')
+    const interaction = () => fireEvent.mouseUp(inputs[0])
+    expect(interaction).not.toThrow()
   })
 })

--- a/packages/ui/src/components/ui/range-slider/range-slider.tsx
+++ b/packages/ui/src/components/ui/range-slider/range-slider.tsx
@@ -14,6 +14,7 @@ type RangeSliderProps = {
   initialMax?: number
   displayValues?: boolean
   onChange?: (values: { min: number; max: number }) => void
+  onFinalChange?: (values: { min: number; max: number }) => void
   values?: Values
 }
 
@@ -25,6 +26,7 @@ export function RangeSlider({
   initialMax = 80,
   displayValues,
   onChange,
+  onFinalChange,
   values,
 }: RangeSliderProps) {
   const clamp = (value: number, minValue: number, maxValue: number) =>
@@ -48,6 +50,10 @@ export function RangeSlider({
     const value = Math.max(Number(e.target.value), minVal + step)
     setMaxVal(value)
     onChange?.({ min: minVal, max: value })
+  }
+
+  const handleInteractionEnd = () => {
+    onFinalChange?.({ min: minVal, max: maxVal })
   }
 
   useEffect(() => {
@@ -100,6 +106,8 @@ export function RangeSlider({
           step={step}
           value={minVal}
           onChange={handleMinChange}
+          onMouseUp={handleInteractionEnd}
+          onTouchEnd={handleInteractionEnd}
           className={thumbClassName}
         />
 
@@ -110,6 +118,8 @@ export function RangeSlider({
           step={step}
           value={maxVal}
           onChange={handleMaxChange}
+          onMouseUp={handleInteractionEnd}
+          onTouchEnd={handleInteractionEnd}
           className={thumbClassName}
         />
       </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-31 20:23:09 UTC

<h3>Greptile Summary</h3>


Added `onFinalChange` prop to RangeSlider component that triggers a callback when user interaction ends, allowing parent components to distinguish between intermediate changes (during dragging) and final values (after release).

**Key Changes:**
- New optional `onFinalChange` prop with same signature as `onChange`
- `handleInteractionEnd` function calls `onFinalChange` with current min/max values
- Event handlers added: `onMouseUp` and `onTouchEnd` on both range inputs

**Issue Found:**
- Missing keyboard interaction support - the callback won't fire when users adjust slider values using arrow keys, only mouse/touch interactions are covered

<h3>Confidence Score: 3/5</h3>


- Safe to merge with minor functional gap - works for mouse/touch but incomplete keyboard support
- The implementation correctly handles mouse and touch interactions, but keyboard navigation (arrow keys) won't trigger `onFinalChange`. This creates inconsistent behavior across input methods. The missing `onKeyUp` handlers need to be added to both range inputs for complete accessibility and functionality.
- packages/ui/src/components/ui/range-slider/range-slider.tsx requires keyboard event handlers

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/ui/src/components/ui/range-slider/range-slider.tsx | 3/5 | Added `onFinalChange` callback prop that fires on mouse/touch end events, but missing keyboard interaction support which will prevent the callback from firing when users adjust values with arrow keys |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant RangeSlider
    participant Parent Component
    
    User->>RangeSlider: Drag min/max thumb (mouse/touch)
    loop During drag
        RangeSlider->>RangeSlider: handleMinChange/handleMaxChange
        RangeSlider->>RangeSlider: Update minVal/maxVal state
        RangeSlider->>Parent Component: onChange({min, max})
    end
    User->>RangeSlider: Release thumb (onMouseUp/onTouchEnd)
    RangeSlider->>RangeSlider: handleInteractionEnd
    RangeSlider->>Parent Component: onFinalChange({min, max})
    
    Note over User,Parent Component: Keyboard interaction (arrow keys) missing onFinalChange trigger
    
    User->>RangeSlider: Press arrow key
    RangeSlider->>RangeSlider: handleMinChange/handleMaxChange
    RangeSlider->>Parent Component: onChange({min, max})
    Note over RangeSlider,Parent Component: onFinalChange NOT called on keyboard release
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->